### PR TITLE
Timing Issue | Validation | Workflows selection

### DIFF
--- a/ui/client/src/components/agentic-ai/graphs/ReactFlowGraph.tsx
+++ b/ui/client/src/components/agentic-ai/graphs/ReactFlowGraph.tsx
@@ -749,6 +749,18 @@ export default function ReactFlowGraph({
     Record<string, NodeStatus>
   >({});
   
+  // Refs to hold latest validation data - allows accessing current values during async operations
+  // This solves the race condition: when graph loading completes, we can immediately apply
+  // whatever validation results are available, without needing an intermediate state
+  const validationResultsRef = useRef(validationResults);
+  const isValidatingRef = useRef(isValidating);
+  
+  // Keep refs synchronized with props
+  useEffect(() => {
+    validationResultsRef.current = validationResults;
+    isValidatingRef.current = isValidating;
+  }, [validationResults, isValidating]);
+  
   // Validation modal state
   const [selectedValidationResult, setSelectedValidationResult] = useState<ElementValidationResult | null>(null);
   const [isValidationModalOpen, setIsValidationModalOpen] = useState(false);
@@ -864,7 +876,30 @@ export default function ReactFlowGraph({
         const { nodes: newNodes, edges: newEdges } =
           parseGraphFlow(targetBlueprintObj.spec_dict, fetchResourceById);
 
-        setNodes(newNodes);
+        // Apply validation data directly to nodes during loading
+        // This handles the case where validation finished before graph loading
+        const currentValidationResults = validationResultsRef.current;
+        const currentIsValidating = isValidatingRef.current;
+        
+        const nodesWithValidation = newNodes.map((node) => {
+          // Only validationResult is node-specific (looked up by node's rid)
+          const nodeRid = node.data.workspaceData?.rid;
+          const validationResult = nodeRid && currentValidationResults 
+            ? currentValidationResults[nodeRid] 
+            : undefined;
+          
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              validationResult,
+              isValidating: currentIsValidating,
+              onShowValidationDetails: handleShowValidationDetails,
+            },
+          };
+        });
+
+        setNodes(nodesWithValidation);
         setEdges(newEdges);
 
         // Auto-fit and zoom after loading
@@ -910,20 +945,31 @@ export default function ReactFlowGraph({
     }
   }, [nodes, edges, isLoading, fitView, zoomOut]);
 
-  // Update nodes with validation data when validationResults, isValidating, or nodes length changes
-  // Using nodes.length as dependency ensures this runs after nodes are loaded
+  // Update nodes with validation data when validation state changes
+  // This handles the case where validation completes AFTER nodes are already loaded
+  // (The case where validation finishes first is handled in convertGraphFlowToReactFlow)
   useEffect(() => {
-    if (nodes.length === 0) return;
-    
-    // Skip if there's no validation data to apply
-    if (!isValidating && Object.keys(validationResults || {}).length === 0) return;
-    
-    setNodes((currentNodes) =>
-      currentNodes.map((node) => {
-        // Look up validation result by node's workspaceData.rid (element_rid)
-        const nodeRid = node.data.workspaceData?.rid;;
+    setNodes((currentNodes) => {
+      // Skip if no nodes loaded yet - validation will be applied during graph loading
+      if (currentNodes.length === 0) return currentNodes;
+      
+      // Check if any node actually needs an update to avoid unnecessary re-renders
+      let hasChanges = false;
+      const updatedNodes = currentNodes.map((node) => {
+        const nodeRid = node.data.workspaceData?.rid;
         const validationResult = nodeRid && validationResults ? validationResults[nodeRid] : undefined;
         
+        // Check if this node's validation data has changed
+        const validationChanged = 
+          node.data.validationResult !== validationResult || 
+          node.data.isValidating !== isValidating ||
+          node.data.onShowValidationDetails !== handleShowValidationDetails;
+        
+        if (!validationChanged) {
+          return node; // No change needed
+        }
+        
+        hasChanges = true;
         return {
           ...node,
           data: {
@@ -933,9 +979,11 @@ export default function ReactFlowGraph({
             onShowValidationDetails: handleShowValidationDetails,
           },
         };
-      })
-    );
-  }, [validationResults, isValidating, handleShowValidationDetails, nodes.length]);
+      });
+      
+      return hasChanges ? updatedNodes : currentNodes;
+    });
+  }, [validationResults, isValidating, handleShowValidationDetails, setNodes]);
 
   if (isLoading) {
     return (


### PR DESCRIPTION
Timing issue with my code, Under the `Agentic AI Workflows` page, each time user change between different workflows my system triggers 2 API calls.

`
`blueprint.validate` API vall and another API call for `blueprints/available.blueprints.resolved.get?userId={}`.
`

The problem is that sometimes when the chosen blueprint is really thick (in terms of the number of elements it's composed of) the validation API can finish very fast, faster than the other API calls, once all the APIs happening parallely which raise a timing bug.

What happens in that in some scenarios the validation return False, therefore we expect to see the `Load Workflow` btn disabled, and also to see warning btn attached to each Node in the graph that is consider invalid. But due to the timing issue what happens is that the `Load Workflow` btn is ENABLED and we can't see any nodes in the graph with ERRORS (warning icons attached to them) it seems to happen since the @/home/cloud-user/Projects/unifai/ui/client/src/components/agentic-ai/graphs/ReactFlowGraph.tsx doesn't get the response from the validation API, same has happen with the `Load Workflow` btn which doesn't turn out to be DISABLED probably since he doen't get the STATE right.

In other scenarios when all worked as expected, first the `Load Workflow` btn showed with a loader than it turns out to ENABLED / DISABLED, when the timing issue I described happens, note that the btn never turned out to appear as `Loading..` since it also probably doesn't get LOADING state which lead to the entire timing error.