### PR TITLE
improve-look-of-enable-sharing-button

### DIFF
--- a/ui/client/src/components/agentic-ai/ShareWorkflow.tsx
+++ b/ui/client/src/components/agentic-ai/ShareWorkflow.tsx
@@ -10,6 +10,7 @@ import { constructShareLink } from "@/utils/blueprintHelpers";
 import SimpleTooltip from "@/components/shared/SimpleTooltip";
 import { UmamiTrack } from "@/components/ui/umamitrack";
 import { UmamiEvents } from "@/config/umamiEvents";
+import { cn } from "@/lib/utils";
 
 interface ShareWorkflowProps {
   blueprintId: string;
@@ -116,27 +117,25 @@ export default function ShareWorkflow({
   };
 
   const tooltipContent = getTooltipContent();
+  const isClickable = !isValidating && !isSharingDisabled && !isLoading;
+
 
   return (
     <div className={`space-y-4 ${className}`}>
-      <div className="flex items-center justify-between">
+      <div
+        className={cn(
+          "flex items-center justify-between rounded-md px-1 py-1",
+          isClickable ? "cursor-pointer hover:bg-background-surface" : "cursor-not-allowed opacity-60")}
+        onClick={() => {if (!isClickable) return; handleToggle(!enabled);}}
+      >
         <div className="flex items-center space-x-2">
-          {isLoading ? (
-            <Loader2 className="h-4 w-4 text-gray-400 animate-spin" />
-          ) : isValidating ? (
-            <Loader2 className="h-4 w-4 text-gray-400 animate-spin" />
-          ) : (
-            <Share2 className="h-4 w-4 text-gray-400" />
-          )}
-          <Label htmlFor="share-toggle" className="text-sm font-medium">
-            {isLoading 
-              ? (enabled ? "Disabling..." : "Enabling...")
-              : isValidating
-                ? "Validating..."
-                : "Enable Public Chat Sharing"
-            }
+          <Share2 className="h-4 w-4 text-gray-400" />
+          
+          <Label className={cn("text-sm font-medium pointer-events-none", !isClickable && "text-gray-400")}>
+            {isLoading ? (enabled ? "Disabling..." : "Enabling...") : isValidating ? "Validating..." : "Enable Public Chat Sharing" }
           </Label>
         </div>
+        
         <SimpleTooltip content={tooltipContent}>
           <span>
             <Switch
@@ -144,10 +143,17 @@ export default function ShareWorkflow({
               checked={enabled}
               onCheckedChange={handleToggle}
               disabled={isSharingDisabled}
-              className={isSharingDisabled && !isLoading ? 'opacity-50 cursor-not-allowed' : ''}
+              onClick={(e) => e.stopPropagation()}
+              className={`
+                data-[state=unchecked]:bg-gray-400
+                data-[state=unchecked]:data-[disabled]:bg-gray-200
+                data-[state=checked]:bg-primary
+                data-[disabled]:opacity-60
+              `}
             />
           </span>
         </SimpleTooltip>
+        
       </div>
 
       {/* Warning for shared but invalid blueprints */}

--- a/ui/client/src/components/shared/SimpleTooltip.tsx
+++ b/ui/client/src/components/shared/SimpleTooltip.tsx
@@ -8,12 +8,12 @@ interface SimpleTooltipProps {
   skipProvider?: boolean;
 }
 
-export default function SimpleTooltip({ 
-  content, 
-  children, 
-  delayDuration = 300,
-  skipProvider = false
-}: SimpleTooltipProps) {
+export default function SimpleTooltip({content, children, delayDuration = 300, skipProvider = false}: SimpleTooltipProps) {
+
+  if (!content) {
+    return <>{children}</>;
+  }
+
   const tooltip = (
     <Tooltip>
       <TooltipTrigger asChild>


### PR DESCRIPTION
As per Omri's request this small UI fix contain:
1. Not displaying anything when the tooltip content is empty (instead of a small bug we currently have where it displays a small empty box).
2. Make sure the entire title in the enable sharing block is displayed as clickable under the mouse cursor.
3. Make the switch button a bit lighter so it will be more visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved workflow sharing interface with enhanced visual feedback: cursor styling adjustments for better user guidance, opacity changes to indicate non-interactive states, and dynamic label text color adjustments that reflect interaction availability.

* **Refactor**
  * Optimized tooltip component code structure with streamlined implementation and refined rendering logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->