### PR TITLE
Genie 896/story/tag based retriever slack

### DIFF
--- a/multi-agent/actions/providers/dataflow/get_available_slack_channels/__init__.py
+++ b/multi-agent/actions/providers/dataflow/get_available_slack_channels/__init__.py
@@ -1,0 +1,1 @@
+from .get_available_slack_channels import GetAvailableSlackChannelsAction

--- a/multi-agent/actions/providers/dataflow/get_available_slack_channels/get_available_slack_channels.py
+++ b/multi-agent/actions/providers/dataflow/get_available_slack_channels/get_available_slack_channels.py
@@ -1,0 +1,74 @@
+from typing import List, Optional, Dict, Any
+from actions.common.base_action import BaseAction
+from actions.common.action_models import BaseActionInput, BaseActionOutput, ActionType
+from elements.providers.dataflow_client.config import DataflowProviderConfig
+from elements.providers.dataflow_client.dataflow_provider_factory import DataflowProviderFactory
+from elements.providers.dataflow_client.identifiers import Identifier as DataFlowProviderIdentifier
+from elements.retrievers.slack.identifiers import Identifier as RetrieverIdentifier
+from core.enums import ResourceCategory
+
+
+class GetAvailableSlackChannelsInput(BaseActionInput):
+    """Input for fetching available embedded Slack channels"""
+    limit: int = 50
+    cursor: Optional[str] = None
+    search_regex: Optional[str] = None
+
+
+class GetAvailableSlackChannelsOutput(BaseActionOutput):
+    """Output for available Slack channels"""
+    channels: List[Dict[str, Any]] = []
+    next_cursor: Optional[str] = None
+    has_more: bool = False
+    total: int = 0
+
+
+class GetAvailableSlackChannelsAction(BaseAction):
+    """
+    Fetches available embedded Slack channels from Dataflow service (sync).
+    """
+
+    uid = "dataflow.get_available_slack_channels"
+    name = "get_available_slack_channels"
+    description = "Retrieve available embedded Slack channels from the Dataflow service"
+    action_type = ActionType.DISCOVERY
+    input_schema = GetAvailableSlackChannelsInput
+    output_schema = GetAvailableSlackChannelsOutput
+    version = "1.0.0"
+    tags = {"dataflow", "discovery", "slack", "channels"}
+    elements = {(ResourceCategory.PROVIDER.value, DataFlowProviderIdentifier.TYPE),
+                (ResourceCategory.RETRIEVER.value, RetrieverIdentifier.TYPE)}
+
+    def execute(
+            self,
+            input_data: GetAvailableSlackChannelsInput,
+            context: Optional[Dict[str, Any]] = None
+    ) -> GetAvailableSlackChannelsOutput:
+        """Execute Slack channels discovery (sync)."""
+        try:
+            config = DataflowProviderConfig()
+            factory = DataflowProviderFactory()
+            provider = factory.create(config)
+
+            response = provider.get_available_slack_channels(
+                limit=input_data.limit,
+                cursor=input_data.cursor,
+                search_regex=input_data.search_regex,
+            )
+
+            return GetAvailableSlackChannelsOutput(
+                success=True,
+                message=f"Found {response.total} channels",
+                channels=[ch.model_dump() for ch in response.channels],
+                next_cursor=response.nextCursor,
+                has_more=response.hasMore,
+                total=response.total
+            )
+
+        except Exception as e:
+            return GetAvailableSlackChannelsOutput(
+                success=False,
+                message=f"Failed to retrieve Slack channels: {str(e)}",
+                channels=[],
+                total=0
+            )

--- a/multi-agent/actions/providers/dataflow/get_available_slack_tags/__init__.py
+++ b/multi-agent/actions/providers/dataflow/get_available_slack_tags/__init__.py
@@ -1,0 +1,1 @@
+from .get_available_slack_tags import GetAvailableSlackTagsAction

--- a/multi-agent/actions/providers/dataflow/get_available_slack_tags/get_available_slack_tags.py
+++ b/multi-agent/actions/providers/dataflow/get_available_slack_tags/get_available_slack_tags.py
@@ -1,0 +1,74 @@
+from typing import List, Optional, Dict, Any
+from actions.common.base_action import BaseAction
+from actions.common.action_models import BaseActionInput, BaseActionOutput, ActionType
+from elements.providers.dataflow_client.config import DataflowProviderConfig
+from elements.providers.dataflow_client.dataflow_provider_factory import DataflowProviderFactory
+from elements.providers.dataflow_client.identifiers import Identifier as DataFlowProviderIdentifier
+from elements.retrievers.slack.identifiers import Identifier as RetrieverIdentifier
+from core.enums import ResourceCategory
+
+
+class GetAvailableSlackTagsInput(BaseActionInput):
+    """Input for fetching available Slack tags"""
+    limit: int = 50
+    cursor: Optional[str] = None
+    search_regex: Optional[str] = None
+
+
+class GetAvailableSlackTagsOutput(BaseActionOutput):
+    """Output for available Slack tags"""
+    tags: List[str] = []
+    next_cursor: Optional[str] = None
+    has_more: bool = False
+    total: int = 0
+
+
+class GetAvailableSlackTagsAction(BaseAction):
+    """
+    Fetches available tags from Slack sources via Dataflow service (sync).
+    """
+
+    uid = "dataflow.get_available_slack_tags"
+    name = "get_available_slack_tags"
+    description = "Retrieve available tags from Slack sources via the Dataflow service"
+    action_type = ActionType.DISCOVERY
+    input_schema = GetAvailableSlackTagsInput
+    output_schema = GetAvailableSlackTagsOutput
+    version = "1.0.0"
+    tags = {"dataflow", "discovery", "slack", "tags"}
+    elements = {(ResourceCategory.PROVIDER.value, DataFlowProviderIdentifier.TYPE),
+                (ResourceCategory.RETRIEVER.value, RetrieverIdentifier.TYPE)}
+
+    def execute(
+            self,
+            input_data: GetAvailableSlackTagsInput,
+            context: Optional[Dict[str, Any]] = None
+    ) -> GetAvailableSlackTagsOutput:
+        """Execute Slack tags discovery (sync)."""
+        try:
+            config = DataflowProviderConfig()
+            factory = DataflowProviderFactory()
+            provider = factory.create(config)
+
+            response = provider.get_available_slack_tags(
+                limit=input_data.limit,
+                cursor=input_data.cursor,
+                search_regex=input_data.search_regex,
+            )
+
+            return GetAvailableSlackTagsOutput(
+                success=True,
+                message=f"Found {response.total} tags",
+                tags=[t.label for t in response.options],
+                next_cursor=response.nextCursor,
+                has_more=response.hasMore,
+                total=response.total
+            )
+
+        except Exception as e:
+            return GetAvailableSlackTagsOutput(
+                success=False,
+                message=f"Failed to retrieve Slack tags: {str(e)}",
+                tags=[],
+                total=0
+            )

--- a/multi-agent/elements/providers/dataflow_client/client.py
+++ b/multi-agent/elements/providers/dataflow_client/client.py
@@ -11,6 +11,7 @@ from pydantic import HttpUrl
 from .models import (
     AvailableTagsResponse,
     AvailableDocsResponse,
+    AvailableChannelsResponse,
     QueryMatchResponse,
     HealthResponse,
 )
@@ -42,6 +43,8 @@ class DataflowClient:
     TAGS_ENDPOINT = "/api/docs/available.tags.get"
     DOCS_ENDPOINT = "/api/docs/available.docs.get"
     QUERY_ENDPOINT = "/api/docs/query.match"
+    SLACK_TAGS_ENDPOINT = "/api/slack/available.tags.get"
+    SLACK_CHANNELS_ENDPOINT = "/api/slack/available.channels.get"
 
     def __init__(
             self,
@@ -218,6 +221,84 @@ class DataflowClient:
         except httpx.HTTPStatusError as e:
             raise DataflowClientError(
                 f"Query failed: {e.response.status_code}"
+            ) from e
+        except httpx.RequestError as e:
+            raise DataflowConnectionError(f"Connection error: {e}") from e
+
+    def get_available_slack_tags(
+            self,
+            limit: int = 50,
+            cursor: Optional[str] = None,
+            search_regex: Optional[str] = None,
+    ) -> AvailableTagsResponse:
+        """
+        Fetch available tags from Slack sources.
+
+        Args:
+            limit: Number of tags per page (default 50)
+            cursor: Pagination cursor for subsequent pages
+            search_regex: Regex pattern to filter tags
+
+        Returns:
+            AvailableTagsResponse with tags and pagination info
+        """
+        self._require_connected()
+
+        params: Dict[str, Any] = {"limit": limit}
+        if cursor:
+            params["cursor"] = cursor
+        if search_regex:
+            params["search_regex"] = search_regex
+
+        try:
+            response = self._client.get(
+                self._build_url(self.SLACK_TAGS_ENDPOINT),
+                params=params,
+            )
+            response.raise_for_status()
+            return AvailableTagsResponse.model_validate(response.json())
+        except httpx.HTTPStatusError as e:
+            raise DataflowClientError(
+                f"Failed to fetch Slack tags: {e.response.status_code}"
+            ) from e
+        except httpx.RequestError as e:
+            raise DataflowConnectionError(f"Connection error: {e}") from e
+
+    def get_available_slack_channels(
+            self,
+            limit: int = 50,
+            cursor: Optional[str] = None,
+            search_regex: Optional[str] = None,
+    ) -> AvailableChannelsResponse:
+        """
+        Fetch available embedded Slack channels.
+
+        Args:
+            limit: Number of channels per page (default 50)
+            cursor: Pagination cursor for subsequent pages
+            search_regex: Regex pattern to filter channels
+
+        Returns:
+            AvailableChannelsResponse with channels and pagination info
+        """
+        self._require_connected()
+
+        params: Dict[str, Any] = {"limit": limit}
+        if cursor:
+            params["cursor"] = cursor
+        if search_regex:
+            params["search_regex"] = search_regex
+
+        try:
+            response = self._client.get(
+                self._build_url(self.SLACK_CHANNELS_ENDPOINT),
+                params=params,
+            )
+            response.raise_for_status()
+            return AvailableChannelsResponse.model_validate(response.json())
+        except httpx.HTTPStatusError as e:
+            raise DataflowClientError(
+                f"Failed to fetch Slack channels: {e.response.status_code}"
             ) from e
         except httpx.RequestError as e:
             raise DataflowConnectionError(f"Connection error: {e}") from e

--- a/multi-agent/elements/providers/dataflow_client/dataflow_provider.py
+++ b/multi-agent/elements/providers/dataflow_client/dataflow_provider.py
@@ -10,6 +10,7 @@ from .client import DataflowClient
 from .models import (
     AvailableTagsResponse,
     AvailableDocsResponse,
+    AvailableChannelsResponse,
     QueryMatchResponse,
 )
 
@@ -131,6 +132,54 @@ class DataflowProvider:
         """
         with self._create_client() as client:
             return client.get_available_docs(
+                limit=limit,
+                cursor=cursor,
+                search_regex=search_regex,
+            )
+
+    def get_available_slack_tags(
+            self,
+            limit: int = 50,
+            cursor: Optional[str] = None,
+            search_regex: Optional[str] = None,
+    ) -> AvailableTagsResponse:
+        """
+        Fetch available tags from Slack sources.
+
+        Args:
+            limit: Number of tags per page
+            cursor: Pagination cursor
+            search_regex: Filter pattern
+
+        Returns:
+            AvailableTagsResponse with tags and pagination
+        """
+        with self._create_client() as client:
+            return client.get_available_slack_tags(
+                limit=limit,
+                cursor=cursor,
+                search_regex=search_regex,
+            )
+
+    def get_available_slack_channels(
+            self,
+            limit: int = 50,
+            cursor: Optional[str] = None,
+            search_regex: Optional[str] = None,
+    ) -> AvailableChannelsResponse:
+        """
+        Fetch available embedded Slack channels.
+
+        Args:
+            limit: Number of channels per page
+            cursor: Pagination cursor
+            search_regex: Filter pattern
+
+        Returns:
+            AvailableChannelsResponse with channels and pagination
+        """
+        with self._create_client() as client:
+            return client.get_available_slack_channels(
                 limit=limit,
                 cursor=cursor,
                 search_regex=search_regex,

--- a/multi-agent/elements/providers/dataflow_client/models.py
+++ b/multi-agent/elements/providers/dataflow_client/models.py
@@ -33,6 +33,20 @@ class AvailableDocsResponse(BaseModel):
     total: int = 0
 
 
+class ChannelInfo(BaseModel):
+    """Single channel info from available channels response."""
+    name: str
+    id: str
+
+
+class AvailableChannelsResponse(BaseModel):
+    """Response from /api/slack/available.channels.get"""
+    channels: List[ChannelInfo]
+    nextCursor: Optional[str] = None
+    hasMore: bool = False
+    total: int = 0
+
+
 class QueryMatchResult(BaseModel):
     """Single match result from query."""
     content: str

--- a/multi-agent/elements/retrievers/slack/config.py
+++ b/multi-agent/elements/retrievers/slack/config.py
@@ -1,8 +1,8 @@
-from typing import Literal
+from typing import Dict, List, Literal, Optional
 from .identifiers import Identifier
 from pydantic import Field, HttpUrl
 from elements.retrievers.common.base_config import BaseRetrieverConfig
-from core.field_hints import HiddenHint
+from core.field_hints import ActionHint, HintType, HiddenHint, SelectionType
 
 
 class SlackRetrieverConfig(BaseRetrieverConfig):
@@ -24,4 +24,34 @@ class SlackRetrieverConfig(BaseRetrieverConfig):
     threshold: float = Field(
         0.3, ge=0.0, le=1.0,
         description="Minimum relevance score to include a message"
+    )
+
+    channels: Optional[List[Dict]] = Field(
+        default=None,
+        description="Filter results to specific Slack channels",
+        json_schema_extra=ActionHint(
+            action_uid="dataflow.get_available_slack_channels",
+            display_name="channels",
+            hint_type=HintType.POPULATE,
+            selection_type=SelectionType.MANUAL,
+            field_mapping="channels",
+            display_field="name",
+            multi_select=True,
+            pagination=True,
+            search=True,
+        ).to_hints()
+    )
+
+    tags: Optional[List[str]] = Field(
+        default=None,
+        description="Filter results by tags",
+        json_schema_extra=ActionHint(
+            action_uid="dataflow.get_available_slack_tags",
+            hint_type=HintType.POPULATE,
+            selection_type=SelectionType.MANUAL,
+            field_mapping="tags",
+            multi_select=True,
+            pagination=True,
+            search=True,
+        ).to_hints()
     )

--- a/multi-agent/elements/retrievers/slack/slack_retriever.py
+++ b/multi-agent/elements/retrievers/slack/slack_retriever.py
@@ -1,5 +1,5 @@
 import requests
-from typing import Any
+from typing import Any, Dict, List, Optional
 from elements.retrievers.common.base_retriever import BaseRetriever
 from pydantic import HttpUrl
 from core.context import get_current_context
@@ -12,18 +12,31 @@ class SlackRetriever(BaseRetriever):
 
     def __init__(self, api_url: HttpUrl,
                  top_k_results: int,
-                 threshold: float):
+                 threshold: float,
+                 channels: Optional[List[Dict]] = None,
+                 tags: Optional[List[str]] = None):
         self.api_url = str(api_url)
         self.top_k = top_k_results
         self.threshold = threshold
+        self.channels = channels
+        self.tags = tags
 
     def retrieve(self, query: str) -> Any:
+        context = get_current_context()
+
         params = {
             "query": query,
             "top_k_results": self.top_k,
-            "scope": get_current_context().scope,
-            "loggedInUser": get_current_context().logged_in_user
+            "scope": context.scope,
+            "loggedInUser": context.logged_in_user
         }
+
+        # Extract channel IDs from channels list
+        channel_ids = [ch['id'] for ch in self.channels] if self.channels else None
+        if channel_ids:
+            params["channelIds"] = channel_ids
+        if self.tags:
+            params["tags"] = self.tags
 
         resp = requests.get(self.api_url, params=params)
         resp.raise_for_status()

--- a/multi-agent/elements/retrievers/slack/slack_retriever_factory.py
+++ b/multi-agent/elements/retrievers/slack/slack_retriever_factory.py
@@ -12,10 +12,14 @@ class SlackRetrieverFactory(BaseFactory[SlackRetrieverConfig, SlackRetriever]):
 
     def create(self, cfg: SlackRetrieverConfig, **kwargs: Any) -> SlackRetriever:
         try:
-            return SlackRetriever(api_url=cfg.api_url,
-                                  top_k_results=cfg.top_k_results,
-                                  threshold=cfg.threshold)
+            return SlackRetriever(
+                api_url=cfg.api_url,
+                top_k_results=cfg.top_k_results,
+                threshold=cfg.threshold,
+                channels=cfg.channels,
+                tags=cfg.tags,
+            )
         except Exception as e:
             raise PluginConfigurationError(
-                f"SlackRetrieverFactory.create() failed: {e}", cfg.dict()
+                f"SlackRetrieverFactory.create() failed: {e}", cfg.model_dump()
             ) from e

--- a/multi-agent/elements/retrievers/slack/spec/__init__.py
+++ b/multi-agent/elements/retrievers/slack/spec/__init__.py
@@ -1,1 +1,1 @@
-# from .spec import SlackRetrieverElementSpec
+from .spec import SlackRetrieverElementSpec

--- a/rag/bootstrap/app_container.py
+++ b/rag/bootstrap/app_container.py
@@ -308,15 +308,26 @@ def doc_validators():
     )
 
 
+def _slack_connector_for_validator():
+    """Return a Slack connector when default project has tokens, else None (graceful fallback)."""
+    manager = slack_config_manager()
+    try:
+        tokens = manager.get_project_tokens("example-project")
+        if tokens.get("bot_token"):
+            return slack_connector("example-project")
+    except KeyError:
+        pass
+    return None
+
+
 @lru_cache(maxsize=1)
 def slack_validators():
     """Slack validators pipeline factory."""
     from core.data_sources.types.slack.validators.factory import SlackValidators
     from core.data_sources.types.slack.validators.channel_bot_installation_validator import ChannelBotInstallationValidator
     from infrastructure.sources.slack.validator.bot_installation_checker import BotInstallationCheckerAdapter, MembershipUpdaterAdapter
-    
-    # TODO: Inject proper Slack connector based on project (None for now - graceful fallback)
-    bot_checker = BotInstallationCheckerAdapter(slack_connector=None)
+
+    bot_checker = BotInstallationCheckerAdapter(slack_connector=_slack_connector_for_validator())
     membership_updater = MembershipUpdaterAdapter(storage=slack_channel_repository())
     
     return SlackValidators(
@@ -473,6 +484,16 @@ def slack_stats_service():
     return SlackStatsService(data_source_service=data_source_service())
 
 
+@lru_cache(maxsize=1)
+def slack_service():
+    """Slack-specific application service (tags, channel queries)."""
+    from core.data_sources.types.slack.slack_service import SlackService
+    return SlackService(
+        data_source_service=data_source_service(),
+        source_repo=data_source_repository(),
+    )
+
+
 # ══════════════════════════════════════════════════════════════════════════════
 # PIPELINE HANDLERS (Application layer - source-specific orchestration)
 # ══════════════════════════════════════════════════════════════════════════════
@@ -482,7 +503,7 @@ def slack_pipeline_handler():
     """Slack pipeline handler with injected dependencies."""
     from core.data_sources.types.slack.pipeline_handler import SlackPipelineHandler
     return SlackPipelineHandler(
-        connector=slack_connector("default"),
+        connector=slack_connector("example-project"),
         processor=slack_processor(),
         chunker=slack_chunker(),
         embedder=embedding_generator(),

--- a/rag/core/data_sources/types/slack/slack_service.py
+++ b/rag/core/data_sources/types/slack/slack_service.py
@@ -1,0 +1,120 @@
+"""Slack-specific application service."""
+from typing import Dict, List, Optional, Any
+
+from core.data_sources.service import DataSourceService
+from core.data_sources.domain.repository import DataSourceRepository
+from core.pagination.domain.model import PaginatedResult
+
+
+class SlackService:
+    """
+    Application service for Slack-specific operations.
+    
+    Handles queries and business logic specific to SLACK sources,
+    such as retrieving tags from successfully processed channels.
+    
+    Uses DataSourceService for shared functionality like pipeline stats enrichment.
+    """
+
+    def __init__(
+        self,
+        data_source_service: DataSourceService,
+        source_repo: DataSourceRepository,
+    ):
+        self._data_source_service = data_source_service
+        self._source_repo = source_repo
+
+    def get_available_tags(
+        self,
+        cursor: Optional[str] = None,
+        limit: int = 50,
+        search: Optional[str] = None,
+    ) -> PaginatedResult[Dict[str, str]]:
+        """
+        Get tags from DONE Slack channels only (for UI dropdowns / retriever config).
+        
+        Filters to only include tags from successfully processed Slack sources.
+        
+        Args:
+            cursor: Pagination cursor
+            limit: Max tags to return
+            search: Filter tags by prefix (case-insensitive)
+            
+        Returns:
+            PaginatedResult with tag options [{label, value}]
+        """
+        # Get all DONE sources
+        all_sources = self._source_repo.find_all(source_type="SLACK")
+        enriched = self._data_source_service.enrich_with_pipeline_stats(all_sources)
+        done_sources = [s for s in enriched if s.get("status") == "DONE"]
+        
+        # Extract unique tags from DONE sources
+        all_tags: set = set()
+        for s in done_sources:
+            all_tags.update(s.get("tags", []))
+        
+        # Apply search filter (case-insensitive prefix match)
+        if search:
+            search_lower = search.lower()
+            all_tags = {t for t in all_tags if t.lower().startswith(search_lower)}
+        
+        # Sort alphabetically and paginate
+        sorted_tags = sorted(all_tags)
+        skip = int(cursor) if cursor and cursor.isdigit() else 0
+        page = sorted_tags[skip:skip + limit]
+        
+        next_cursor = str(skip + len(page)) if skip + len(page) < len(sorted_tags) else None
+        
+        return PaginatedResult(
+            data=[{"label": t, "value": t} for t in page],
+            next_cursor=next_cursor,
+            has_more=next_cursor is not None,
+            total=len(sorted_tags),
+        )
+
+    def get_available_channels(
+        self,
+        cursor: Optional[str] = None,
+        limit: int = 50,
+        search: Optional[str] = None,
+    ) -> PaginatedResult[Dict[str, str]]:
+        """
+        Get embedded Slack channels (DONE status) for UI dropdowns / retriever config.
+        
+        Args:
+            cursor: Pagination cursor
+            limit: Max channels to return
+            search: Filter channels by name (case-insensitive prefix match)
+            
+        Returns:
+            PaginatedResult with channel options [{name, id}]
+        """
+        all_sources = self._source_repo.find_all(source_type="SLACK")
+        enriched = self._data_source_service.enrich_with_pipeline_stats(all_sources)
+        done_sources = [s for s in enriched if s.get("status") == "DONE"]
+        
+        # Build channel list
+        channels = [
+            {"name": s.get("source_name", ""), "id": s.get("source_id", "")}
+            for s in done_sources
+        ]
+        
+        # Apply search filter
+        if search:
+            search_lower = search.lower()
+            channels = [c for c in channels if c["name"].lower().startswith(search_lower)]
+        
+        # Sort by name
+        channels.sort(key=lambda c: c["name"].lower())
+        
+        skip = int(cursor) if cursor and cursor.isdigit() else 0
+        page = channels[skip:skip + limit]
+        
+        next_cursor = str(skip + len(page)) if skip + len(page) < len(channels) else None
+        
+        return PaginatedResult(
+            data=page,
+            next_cursor=next_cursor,
+            has_more=next_cursor is not None,
+            total=len(channels),
+        )

--- a/rag/infrastructure/http/slack.py
+++ b/rag/infrastructure/http/slack.py
@@ -4,6 +4,7 @@ from webargs import fields
 
 from bootstrap.app_container import (
     slack_connector,
+    slack_service,
     vector_stats_service,
     retrieval_service,
     slack_stats_service,
@@ -62,6 +63,70 @@ def get_available_channels(types, cursor, limit, search_regex):
         return jsonify({"error": str(e)}), 500
 
 
+@slack_bp.route("/available.tags.get", methods=["GET"])
+@from_query({
+    "cursor": fields.Str(required=False, load_default=""),
+    "limit": fields.Int(required=False, load_default=50),
+    "search_regex": fields.Str(required=False, load_default=None),
+})
+def get_available_slack_tags(cursor="", limit=50, search_regex=None):
+    """
+    Get paginated list of available tags from DONE Slack channels.
+    Used for tag dropdown selection in the UI and retriever config.
+    
+    Response format matches docs endpoint: options array with label/value pairs.
+    """
+    try:
+        result = slack_service().get_available_tags(
+            cursor=cursor,
+            limit=limit,
+            search=search_regex,
+        )
+        
+        return jsonify({
+            "options": result.data,
+            "nextCursor": result.next_cursor,
+            "hasMore": result.has_more,
+            "total": result.total,
+        }), 200
+        
+    except Exception as e:
+        logger.error(f"Failed to get available Slack tags: {str(e)}")
+        return jsonify({"error": str(e)}), 500
+
+
+@slack_bp.route("/available.channels.get", methods=["GET"])
+@from_query({
+    "cursor": fields.Str(required=False, load_default=""),
+    "limit": fields.Int(required=False, load_default=50),
+    "search_regex": fields.Str(required=False, load_default=None),
+})
+def get_available_embedded_channels(cursor="", limit=50, search_regex=None):
+    """
+    Get paginated list of embedded (DONE) Slack channels.
+    Used for channel dropdown selection in retriever config.
+    
+    Response format: channels array with name/id pairs.
+    """
+    try:
+        result = slack_service().get_available_channels(
+            cursor=cursor,
+            limit=limit,
+            search=search_regex,
+        )
+        
+        return jsonify({
+            "channels": result.data,
+            "nextCursor": result.next_cursor,
+            "hasMore": result.has_more,
+            "total": result.total,
+        }), 200
+        
+    except Exception as e:
+        logger.error(f"Failed to get available embedded Slack channels: {str(e)}")
+        return jsonify({"error": str(e)}), 500
+
+
 @slack_bp.route("/slack.channel.chunks", methods=["GET"])
 @from_query({"channel_name": fields.Str(required=True)})
 def get_channel_chunks(channel_name):
@@ -114,9 +179,11 @@ def get_user_info(user_id, include_locale):
     "top_k_results": fields.Int(required=False, load_default=5),
     "scope": fields.Str(required=False, load_default="public"),
     "logged_in_user": fields.Str(required=False, load_default="default", data_key="loggedInUser"),
+    "channel_ids": fields.List(fields.Str(), required=False, load_default=None, data_key="channelIds"),
+    "tags": fields.List(fields.Str(), required=False, load_default=None),
 })
-def query_match(query, top_k_results, scope, logged_in_user):
-    """Search Slack messages using semantic similarity."""
+def query_match(query, top_k_results, scope, logged_in_user, channel_ids, tags):
+    """Search Slack messages using semantic similarity with optional channel/tag filtering."""
     try:
         svc = retrieval_service("SLACK")
         results = svc.search(
@@ -124,6 +191,8 @@ def query_match(query, top_k_results, scope, logged_in_user):
             limit=top_k_results,
             scope=scope,
             user=logged_in_user,
+            doc_ids=channel_ids,
+            tags=tags,
         )
         
         return jsonify({"search_results": results}), 200

--- a/ui/client/src/api/slack.ts
+++ b/ui/client/src/api/slack.ts
@@ -70,6 +70,7 @@ export interface ChannelWithSettings extends Channel {
     communityPrivacy: 'public' | 'private';
     includeThreads: boolean;
     processFileContent: boolean;
+    tags: string[];
   };
 }
 
@@ -96,6 +97,7 @@ export async function submitSlackChannels(
     channel_name: channel.channel_name,
     channel_id: channel.channel_id,
     is_private: channel.is_private,
+    tags: channel.settings.tags || [],
     // Include settings as additional metadata for backend processing
     metadata: {
       dateRange: channel.settings.dateRange,
@@ -142,6 +144,7 @@ export async function fetchEmbeddedSlackChannels(): Promise<EmbedChannel[]> {
     created: formatDate(item.created_at || ''),
     is_private: item.type_data?.is_private || false,
     communityPrivacy: item.type_data?.communityPrivacy || 'public',
+    tags: item.tags || [],
     // Surface backend error info so UI tooltips can display it
     type_data: {
       last_error: item.type_data?.last_error,
@@ -152,6 +155,13 @@ export async function fetchEmbeddedSlackChannels(): Promise<EmbedChannel[]> {
       : (item.type_data?.start_timestamp ? formatDate(item.type_data.start_timestamp) : undefined),
   }));
 };
+
+export async function updateSlackChannel(sourceId: string, updates: Record<string, unknown>): Promise<void> {
+  await api.put('data_sources/data.source.update', {
+    source_id: sourceId,
+    updates
+  });
+}
 
 export async function deleteSlackChannels(channelIds: string[]): Promise<any> {
   const { data } = await api.delete(`data_sources/data.source.delete`, {

--- a/ui/client/src/features/slack/AddSourceSection.tsx
+++ b/ui/client/src/features/slack/AddSourceSection.tsx
@@ -45,6 +45,7 @@ interface ChannelWithSettings extends Channel {
     communityPrivacy: 'public' | 'private';
     includeThreads: boolean;
     processFileContent: boolean;
+    tags: string[];
   };
 }
 
@@ -216,6 +217,7 @@ const AddSourceSection = forwardRef<AddSourceSectionHandle, AddSourceSectionProp
           communityPrivacy: 'public' as const,
           includeThreads: settingsForThisChannel.includeThreads,
           processFileContent: settingsForThisChannel.processFileContent,
+          tags: settingsForThisChannel.tags || [],
         }
       });
     }

--- a/ui/client/src/features/slack/ChannelSettings.tsx
+++ b/ui/client/src/features/slack/ChannelSettings.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { X, Tag } from 'lucide-react';
 import {
   Select,
   SelectContent,
@@ -13,6 +16,7 @@ export interface ChannelSettingsData {
   dateRange: string;
   includeThreads: boolean;
   processFileContent: boolean;
+  tags: string[];
 }
 
 export interface ChannelSettingsProps {
@@ -26,6 +30,7 @@ export const defaultChannelSettings: ChannelSettingsData = {
   dateRange: '180d',
   includeThreads: true,
   processFileContent: false,
+  tags: [],
 };
 
 export function ChannelSettings({ 
@@ -34,11 +39,32 @@ export function ChannelSettings({
   settings, 
   onSettingsChange 
 }: ChannelSettingsProps) {
+  const [tagInput, setTagInput] = useState('');
+
   const updateSetting = <K extends keyof ChannelSettingsData>(
     key: K, 
     value: ChannelSettingsData[K]
   ) => {
     onSettingsChange(channelId, { ...settings, [key]: value });
+  };
+
+  const handleAddTag = () => {
+    const tag = tagInput.trim().toLowerCase();
+    if (tag && !settings.tags.includes(tag)) {
+      updateSetting('tags', [...settings.tags, tag]);
+    }
+    setTagInput('');
+  };
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    updateSetting('tags', settings.tags.filter(t => t !== tagToRemove));
+  };
+
+  const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAddTag();
+    }
   };
 
   return (
@@ -77,6 +103,39 @@ export function ChannelSettings({
         <p className="text-xs text-gray-400 mt-1">
           How far back to fetch messages
         </p>
+      </div>
+
+      {/* Tags */}
+      <div>
+        <Label className="text-sm flex items-center gap-1.5">
+          <Tag className="h-3.5 w-3.5" />
+          Tags
+        </Label>
+        <p className="text-xs text-gray-400 mt-1 mb-2">
+          Add tags to organize and filter this channel in retrievers
+        </p>
+        {settings.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {settings.tags.map(tag => (
+              <Badge key={tag} variant="outline" className="text-xs px-2 py-0.5 gap-1">
+                {tag}
+                <X
+                  className="h-3 w-3 cursor-pointer hover:text-destructive transition-colors"
+                  onClick={() => handleRemoveTag(tag)}
+                />
+              </Badge>
+            ))}
+          </div>
+        )}
+        <div className="flex gap-2">
+          <Input
+            value={tagInput}
+            onChange={(e) => setTagInput(e.target.value)}
+            onKeyDown={handleTagKeyDown}
+            placeholder="Type tag and press Enter..."
+            className="text-sm dark:bg-zinc-800 dark:!text-white dark:border-zinc-700"
+          />
+        </div>
       </div>
 
       {/* Include Threads - Disabled for now */}

--- a/ui/client/src/features/slack/ChannelSettingsDrawer.tsx
+++ b/ui/client/src/features/slack/ChannelSettingsDrawer.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -17,7 +18,7 @@ import { EmbedChannel } from "@/types";
 import { StatItem, StatsSection } from "./StatsSection";
 import { HiOutlineLockClosed } from "react-icons/hi";
 import { Badge } from "@/components/ui/badge";
-import { X } from "lucide-react";
+import { X, Tag } from "lucide-react";
 
 export interface SettingOption {
   value: string | number;
@@ -55,44 +56,45 @@ export interface ChannelSettingsDrawerProps {
   channel: EmbedChannel;
   isOpen: boolean;
   onClose: () => void;
-  onSave: (values: Record<string, string | boolean>) => void;
+  onSave: (values: Record<string, string | boolean>, tags: string[]) => void;
+  isSaving?: boolean;
 }
 
 const categories: SettingsCategory[] = [
-  {
-    title: "Sync Options",
-    settings: [
-      {
-        id: "updateFrequency",
-        type: "select",
-        label: "Update Frequency",
-        description: "How often to sync new messages",
-        defaultValue: "30",
-        options: [
-          { value: "15", label: "Every 15 minutes" },
-          { value: "30", label: "Every 30 minutes" },
-          { value: "60", label: "Every hour" },
-          { value: "360", label: "Every 6 hours" },
-          { value: "720", label: "Every 12 hours" },
-          { value: "1440", label: "Every day" },
-        ],
-      },
-      {
-        id: "includeThreads",
-        type: "switch",
-        label: "Include Threads",
-        description: "Process conversation threads",
-        defaultValue: true,
-      },
-      {
-        id: "channelActive",
-        type: "switch",
-        label: "Channel Active",
-        description: "Toggle channel processing",
-        defaultValue: true,
-      },
-    ],
-  },
+  // {
+  //   title: "Sync Options",
+  //   settings: [
+  //     {
+  //       id: "updateFrequency",
+  //       type: "select",
+  //       label: "Update Frequency",
+  //       description: "How often to sync new messages",
+  //       defaultValue: "30",
+  //       options: [
+  //         { value: "15", label: "Every 15 minutes" },
+  //         { value: "30", label: "Every 30 minutes" },
+  //         { value: "60", label: "Every hour" },
+  //         { value: "360", label: "Every 6 hours" },
+  //         { value: "720", label: "Every 12 hours" },
+  //         { value: "1440", label: "Every day" },
+  //       ],
+  //     },
+  //     {
+  //       id: "includeThreads",
+  //       type: "switch",
+  //       label: "Include Threads",
+  //       description: "Process conversation threads",
+  //       defaultValue: true,
+  //     },
+  //     {
+  //       id: "channelActive",
+  //       type: "switch",
+  //       label: "Channel Active",
+  //       description: "Toggle channel processing",
+  //       defaultValue: true,
+  //     },
+  //   ],
+  // },
   {
     title: "Historical Data",
     settings: [
@@ -120,9 +122,12 @@ export function ChannelSettingsDrawer({
   isOpen,
   onClose,
   onSave,
+  isSaving = false,
 }: ChannelSettingsDrawerProps) {
 
   const [values, setValues] = useState<Record<string, string | boolean>>({});
+  const [tags, setTags] = useState<string[]>([]);
+  const [tagInput, setTagInput] = useState('');
 
   useEffect(() => {
     if (isOpen) {
@@ -133,16 +138,36 @@ export function ChannelSettingsDrawer({
         });
       });
       setValues(initial);
+      setTags(channel.tags || []);
+      setTagInput('');
     }
-  }, [categories, isOpen]);
+  }, [categories, isOpen, channel]);
 
   const handleChange = (id: string, newValue: string | boolean) => {
     setValues((prev) => ({ ...prev, [id]: newValue }));
   };
 
+  const handleAddTag = () => {
+    const tag = tagInput.trim().toLowerCase();
+    if (tag && !tags.includes(tag)) {
+      setTags(prev => [...prev, tag]);
+    }
+    setTagInput('');
+  };
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    setTags(prev => prev.filter(t => t !== tagToRemove));
+  };
+
+  const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAddTag();
+    }
+  };
+
   const handleSave = () => {
-    onSave(values);
-    onClose();
+    onSave(values, tags);
   };
   
   const channelStats: StatItem[] = [
@@ -165,22 +190,24 @@ export function ChannelSettingsDrawer({
 
   return (
     <motion.div
-      className="bg-background-card shadow-lg border-l border-border rounded-lg"
+      className="bg-card text-card-foreground shadow-2xl rounded-lg overlay-elevation overlay-08 flex flex-col h-full"
      
       style={{ pointerEvents: isOpen ? "auto" : "none" }}
     >
       {isOpen && (
-        <CardContent className="p-6">
-          <div>
-                      <div className="flex items-center justify-between mb-6">
-              <div>
-                <h3 className="text-lg font-semibold text-foreground">Channel Settings</h3>
-               
-              </div>
-              <Button variant="ghost" size="sm" onClick={onClose}>
-                <X className="w-4 h-4" />
-              </Button>
+        <CardContent className="p-6 flex flex-col overflow-hidden">
+          {/* Fixed header */}
+          <div className="flex items-center justify-between mb-6 shrink-0">
+            <div>
+              <h3 className="text-lg font-semibold text-foreground">Channel Settings</h3>
             </div>
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              <X className="w-4 h-4" />
+            </Button>
+          </div>
+
+          {/* Scrollable content */}
+          <div className="overflow-y-auto flex-1 min-h-0 pr-1">
             <div className="space-y-6">
    
             <div className="space-y-4">
@@ -208,8 +235,8 @@ export function ChannelSettingsDrawer({
               
               <div className="grid grid-cols-3 gap-3 text-sm">
                 <div className="text-center p-3 bg-muted/30 rounded-lg">
-                  <p className="text-muted-foreground text-xs uppercase tracking-wide">Progress</p>
-                  {/* <p className="font-semibold text-foreground text-lg">{channel.embeddingProgress || 0}%</p> */}
+                  <p className="text-muted-foreground text-xs uppercase tracking-wide">Last Sync</p>
+                  <p className="font-semibold text-foreground text-sm">{channel.lastSync || '—'}</p>
                 </div>
                 <div className="text-center p-3 bg-muted/30 rounded-lg">
                   <p className="text-muted-foreground text-xs uppercase tracking-wide">Type</p>
@@ -223,6 +250,40 @@ export function ChannelSettingsDrawer({
             </div>
 
             <Separator />
+
+            {/* Tags */}
+            <div className="mb-6">
+              <Label className="text-sm font-medium mb-2 flex items-center gap-1.5">
+                <Tag className="h-3.5 w-3.5" />
+                Tags
+              </Label>
+              <Separator className="bg-gray-800 mb-4" />
+              <p className="text-xs text-gray-400 mb-2">
+                Add tags to organize and filter this channel in retrievers
+              </p>
+              {tags.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mb-2">
+                  {tags.map(tag => (
+                    <Badge key={tag} variant="secondary" className="text-xs px-2 py-0.5 gap-1">
+                      {tag}
+                      <X
+                        className="h-3 w-3 cursor-pointer hover:text-destructive transition-colors"
+                        onClick={() => handleRemoveTag(tag)}
+                      />
+                    </Badge>
+                  ))}
+                </div>
+              )}
+              <div className="flex gap-2">
+                <Input
+                  value={tagInput}
+                  onChange={(e) => setTagInput(e.target.value)}
+                  onKeyDown={handleTagKeyDown}
+                  placeholder="Type tag and press Enter..."
+                  className="text-sm dark:bg-zinc-800 dark:!text-white dark:border-zinc-700"
+                />
+              </div>
+            </div>
 
             {/* Iterate over each category */}
             {categories.map((category, catIdx) => (
@@ -307,12 +368,13 @@ export function ChannelSettingsDrawer({
           </div>
           </div>
           
-          <div className="flex justify-end space-x-2 pt-6 border-t border-border mt-6">
-            <Button variant="outline" onClick={onClose}>
+          {/* Fixed footer */}
+          <div className="flex justify-end space-x-2 pt-6 border-t border-border mt-6 shrink-0">
+            <Button variant="outline" onClick={onClose} disabled={isSaving}>
               Cancel
             </Button>
-            <Button className="bg-secondary" onClick={handleSave}>
-              Save Changes
+            <Button className="bg-secondary" onClick={handleSave} disabled={isSaving}>
+              {isSaving ? 'Saving...' : 'Save Changes'}
             </Button>
           </div>
         </CardContent>

--- a/ui/client/src/features/slack/ChannelTable.tsx
+++ b/ui/client/src/features/slack/ChannelTable.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { FaSync, FaCog, FaPlus, FaTrash, FaUsers, FaGlobe } from "react-icons/fa";
 import { HiOutlineLockClosed } from "react-icons/hi";
 import { useLocation } from "wouter";
-import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { EmbedChannel } from "@/types";
 import { Badge } from "@/components/ui/badge";
@@ -26,6 +26,65 @@ export function isChannelNew(createdAt: Date): boolean {
   const now = new Date()
   const dayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000)
   return createdAt > dayAgo
+}
+
+const TAGS_MAX_VISIBLE = 2;
+
+function TagsCell({ tags }: { tags: string[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (tags.length === 0) {
+    return <span className="text-muted-foreground text-xs">—</span>;
+  }
+
+  const visible = tags.slice(0, TAGS_MAX_VISIBLE);
+  const extra = tags.slice(TAGS_MAX_VISIBLE);
+  const remaining = extra.length;
+
+  return (
+    <div className="flex flex-wrap gap-1 items-center max-w-[220px]">
+      {visible.map(tag => (
+        <Badge key={tag} variant="secondary" className="text-xs px-1.5 py-0">
+          {tag}
+        </Badge>
+      ))}
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            className="flex flex-wrap gap-1 items-center overflow-hidden"
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+          >
+            {extra.map(tag => (
+              <Badge key={tag} variant="secondary" className="text-xs px-1.5 py-0">
+                {tag}
+              </Badge>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+      {remaining > 0 && !expanded && (
+        <Badge
+          variant="outline"
+          className="text-xs px-1.5 py-0 cursor-pointer hover:bg-muted"
+          onClick={(e) => { e.stopPropagation(); setExpanded(true); }}
+        >
+          +{remaining} more
+        </Badge>
+      )}
+      {expanded && remaining > 0 && (
+        <Badge
+          variant="outline"
+          className="text-xs px-1.5 py-0 cursor-pointer hover:bg-muted"
+          onClick={(e) => { e.stopPropagation(); setExpanded(false); }}
+        >
+          Show less
+        </Badge>
+      )}
+    </div>
+  );
 }
 
 export function getColumns(
@@ -70,6 +129,16 @@ export function getColumns(
           </div>
         )
       }
+    },
+    {
+      accessorKey: "tags",
+      header: "Tags",
+      cell: (info) => <TagsCell tags={info.getValue<string[]>() || []} />,
+      filterFn: (row, columnId, filterValue) => {
+        const tags = row.getValue(columnId) as string[];
+        return tags?.some(t => t.toLowerCase().includes(String(filterValue).toLowerCase())) ?? false;
+      },
+      meta: { align: "left", filterType: "text" },
     },
     {
       accessorKey: "status",

--- a/ui/client/src/features/slack/SlackIntegration.tsx
+++ b/ui/client/src/features/slack/SlackIntegration.tsx
@@ -7,7 +7,7 @@ import { PaginatedChannelTable } from "@/features/slack/PaginatedChannelTable";
 import { ChannelSettingsDrawer } from "@/features/slack/ChannelSettingsDrawer";
 import { AnimatePresence, motion } from "framer-motion";
 import { useLocation } from "wouter";
-import { fetchEmbeddedSlackChannels, fetchSystemStats, deleteSlackChannels } from "@/api/slack";
+import { fetchEmbeddedSlackChannels, fetchSystemStats, deleteSlackChannels, updateSlackChannel } from "@/api/slack";
 import { FaHashtag, FaComments, FaSync, FaDatabase } from "react-icons/fa";
 import { useToast } from "@/hooks/use-toast";
 import {
@@ -144,8 +144,31 @@ export default function SlackIntegration() {
     },
   });
 
-  const handleSave = (values: Record<string, string | boolean>) => {
-    setSettingsChannel(null);
+  const [isSavingSettings, setIsSavingSettings] = useState(false);
+
+  const handleSave = async (values: Record<string, string | boolean>, tags: string[]) => {
+    if (!settingsChannel) return;
+    
+    setIsSavingSettings(true);
+    try {
+      await updateSlackChannel(settingsChannel.channel_id, { tags });
+      queryClient.invalidateQueries({ queryKey: ["embeddedSlackChannels"] });
+      toast({
+        title: "Settings Saved",
+        description: `Tags updated for #${settingsChannel.name}.`,
+        variant: "default",
+      });
+      setSettingsChannel(null);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      toast({
+        title: "Save Failed",
+        description: `Unable to save settings: ${errorMessage}`,
+        variant: "destructive",
+      });
+    } finally {
+      setIsSavingSettings(false);
+    }
   };
 
   const handleDeleteChannel = (channel: EmbedChannel) => {
@@ -316,7 +339,7 @@ export default function SlackIntegration() {
               {isError && <div className="text-destructive">Failed to load channels: {error.message}</div>}
 
               {!isLoading && !isError && (
-                <div className="flex gap-4 min-h-[400px] relative">
+                <div className="flex gap-4 min-h-[600px] relative overflow-hidden">
                   <motion.div
                     className="flex transition-all duration-500 ease-in-out"
                     style={{
@@ -340,7 +363,7 @@ export default function SlackIntegration() {
                   <AnimatePresence>
                     {settingsChannel && (
                       <motion.div
-                        className="absolute right-0 top-0 w-[400px] z-10"
+                        className="absolute right-0 top-0 bottom-0 w-[400px] z-10"
                         initial={{ x: 400, opacity: 0 }}
                         animate={{ x: 0, opacity: 1 }}
                         exit={{ x: 400, opacity: 0 }}
@@ -351,6 +374,7 @@ export default function SlackIntegration() {
                           isOpen={settingsChannel !== null}
                           onClose={() => setSettingsChannel(null)}
                           onSave={handleSave}
+                          isSaving={isSavingSettings}
                         />
                       </motion.div>
                     )}

--- a/ui/client/src/types/index.ts
+++ b/ui/client/src/types/index.ts
@@ -71,6 +71,7 @@ export interface EmbedChannel {
   created: string;
   is_private: boolean;
   initialTimestamp: string;
+  tags: string[];
 }
 export interface Document {
   _id: string;


### PR DESCRIPTION
**Tag-Based Retriever for Slack**
**Summary**

- Add tag and channel-based filtering support for the Slack retriever, mirroring the existing document retriever functionality
- Enable adding and editing tags on Slack channels through the UI (Add Channels page + embedded channels table)
- Implement backend endpoints and multi-agent actions for tag/channel discovery and filtered search

**UI Changes**

- ChannelSettings.tsx — Tag input field on the "Add Slack Channels" page, allowing users to assign tags when adding new channels
- ChannelSettingsDrawer.tsx — Tag editing in the channel settings drawer with save/persist support, internal scrolling, and "Last Sync" display
- ChannelTable.tsx — New "Tags" column with expandable/collapsible view (shows 2 tags + "+N more") using framer-motion animation
- AddSourceSection.tsx — Tags included in the embed channel submission payload
- SlackIntegration.tsx — Wired up tag update API calls and drawer save handling
- slack.ts (API) — Added updateSlackChannel() function; updated submitSlackChannels() and fetchEmbeddedSlackChannels() to handle tags

**RAG Backend**

- SlackService (rag/core/data_sources/types/slack/slack_service.py) — New service with get_available_tags() and get_available_channels() methods for paginated tag/channel discovery from DONE sources
- Slack HTTP endpoints (rag/infrastructure/http/slack.py):
- GET /api/slack/available.tags.get — Paginated tags from embedded Slack channels
- GET /api/slack/available.channels.get — Paginated embedded (DONE) Slack channels
- GET /api/slack/query.match — Updated to accept channelIds and tags filter params, passed to RetrievalService.search()
- app_container.py — Registered SlackService singleton

**Multi-Agent**

- SlackRetrieverConfig — Added channels and tags fields with ActionHint decorators (same pattern as DocsDataflowRetrieverConfig)
- SlackRetriever — Passes channelIds and tags as query params to the RAG /api/slack/query.match endpoint
- SlackRetrieverFactory — Passes channels and tags from config to the retriever
- Slack retriever spec — Uncommented import to register in the element catalog
- DataflowClient / DataflowProvider — Added get_available_slack_tags() and get_available_slack_channels() methods + AvailableChannelsResponse / ChannelInfo models

**New actions:**

- dataflow.get_available_slack_channels — Discovery action for populating the channels dropdown in retriever config
- dataflow.get_available_slack_tags — Discovery action for populating the tags dropdown in retriever config
- 