### PR TITLE
Add clone workflow feature

### DIFF
--- a/multi-agent/adapters/inbound/flask/endpoints/blueprints.py
+++ b/multi-agent/adapters/inbound/flask/endpoints/blueprints.py
@@ -324,6 +324,41 @@ def set_metadata(blueprint_id, metadata):
         logger.exception(f"Unexpected error updating metadata for blueprint {blueprint_id}")
         return jsonify({"error": str(e)}), 500
 
+@blueprints_bp.route("/blueprint.clone", methods=["POST"])
+@from_body({
+    "blueprint_id": fields.Str(data_key="blueprintId", required=True),
+    "user_id": fields.Str(data_key="userId", required=True),
+})
+def clone_blueprint(blueprint_id, user_id):
+    """
+    Clone a blueprint and all its dependencies for the same user.
+    Creates a new blueprint with "(copy)" suffix.
+    """
+    try:
+        cloner = current_app.container.share_cloner
+
+        new_blueprint_id, rid_mapping, name_conflicts = cloner.clone_blueprint(
+            blueprint_id=blueprint_id,
+            sender_user_id=user_id,
+            recipient_user_id=user_id,
+        )
+
+        return jsonify({
+            "status": "success",
+            "blueprint_id": new_blueprint_id,
+            "resources_cloned": len(rid_mapping),
+            "name_conflicts": name_conflicts,
+        }), 201
+
+    except BlueprintNotFoundError as e:
+        return jsonify({"status": "error", "error": str(e)}), 404
+    except ValueError as e:
+        return jsonify({"status": "error", "error": str(e)}), 400
+    except Exception as e:
+        logger.exception(f"Unexpected error cloning blueprint {blueprint_id}")
+        return jsonify({"status": "error", "error": str(e)}), 500
+
+
 @blueprints_bp.route("/blueprint.validate", methods=["POST"])
 @from_body({
     "blueprint_id": fields.Str(data_key="blueprintId", required=True),

--- a/multi-agent/adapters/inbound/flask/endpoints/blueprints.py
+++ b/multi-agent/adapters/inbound/flask/endpoints/blueprints.py
@@ -7,6 +7,8 @@ from werkzeug.exceptions import BadRequest
 from typing import Optional
 from mas.blueprints.exceptions import (
     BlueprintNotFoundError,
+    BlueprintAccessDeniedError,
+    BlueprintCloneError,
     BlueprintSaveError,
     BlueprintMetadataError,
 )
@@ -352,8 +354,11 @@ def clone_blueprint(blueprint_id, user_id):
 
     except BlueprintNotFoundError as e:
         return jsonify({"status": "error", "error": str(e)}), 404
-    except ValueError as e:
-        return jsonify({"status": "error", "error": str(e)}), 400
+    except BlueprintAccessDeniedError as e:
+        return jsonify({"status": "error", "error": str(e)}), 403
+    except BlueprintCloneError as e:
+        logger.exception(f"Clone failed for blueprint {blueprint_id}")
+        return jsonify({"status": "error", "error": str(e)}), 500
     except Exception as e:
         logger.exception(f"Unexpected error cloning blueprint {blueprint_id}")
         return jsonify({"status": "error", "error": str(e)}), 500

--- a/multi-agent/adapters/inbound/flask/endpoints/blueprints.py
+++ b/multi-agent/adapters/inbound/flask/endpoints/blueprints.py
@@ -326,23 +326,22 @@ def set_metadata(blueprint_id, metadata):
         logger.exception(f"Unexpected error updating metadata for blueprint {blueprint_id}")
         return jsonify({"error": str(e)}), 500
 
-@blueprints_bp.route("/blueprint.clone", methods=["POST"])
+@blueprints_bp.route("/blueprint.duplicate", methods=["POST"])
 @from_body({
     "blueprint_id": fields.Str(data_key="blueprintId", required=True),
     "user_id": fields.Str(data_key="userId", required=True),
 })
-def clone_blueprint(blueprint_id, user_id):
+def duplicate_blueprint(blueprint_id, user_id):
     """
-    Clone a blueprint and all its dependencies for the same user.
+    Duplicate a blueprint and all its dependencies for the same user.
     Creates a new blueprint with "(copy)" suffix.
     """
     try:
-        cloner = current_app.container.share_cloner
+        svc = current_app.container.share_service
 
-        new_blueprint_id, rid_mapping, name_conflicts = cloner.clone_blueprint(
+        new_blueprint_id, rid_mapping, name_conflicts = svc.duplicate_blueprint(
             blueprint_id=blueprint_id,
-            sender_user_id=user_id,
-            recipient_user_id=user_id,
+            user_id=user_id,
         )
 
         return jsonify({
@@ -357,10 +356,10 @@ def clone_blueprint(blueprint_id, user_id):
     except BlueprintAccessDeniedError as e:
         return jsonify({"status": "error", "error": str(e)}), 403
     except BlueprintCloneError as e:
-        logger.exception(f"Clone failed for blueprint {blueprint_id}")
+        logger.exception(f"Duplicate failed for blueprint {blueprint_id}")
         return jsonify({"status": "error", "error": str(e)}), 500
     except Exception as e:
-        logger.exception(f"Unexpected error cloning blueprint {blueprint_id}")
+        logger.exception(f"Unexpected error duplicating blueprint {blueprint_id}")
         return jsonify({"status": "error", "error": str(e)}), 500
 
 

--- a/multi-agent/adapters/outbound/mongo/blueprint_repository.py
+++ b/multi-agent/adapters/outbound/mongo/blueprint_repository.py
@@ -82,10 +82,6 @@ class MongoBlueprintRepository(BlueprintRepository):
     def exists(self, blueprint_id: str) -> bool:
         return self._col.count_documents({"blueprint_id": blueprint_id}, limit=1) == 1
 
-    def find_by_name(self, user_id: str, name: str) -> BlueprintDocument | None:
-        raw = self._col.find_one({"user_id": user_id, "spec_dict.name": name})
-        return BlueprintDocument(**raw) if raw else None
-
     # --------- listing & counting with optional user filter -------
     def _user_q(self, user_id: str | None) -> Dict[str, Any]:
         return {} if user_id is None else {"user_id": user_id}

--- a/multi-agent/adapters/outbound/mongo/blueprint_repository.py
+++ b/multi-agent/adapters/outbound/mongo/blueprint_repository.py
@@ -49,7 +49,7 @@ class MongoBlueprintRepository(BlueprintRepository):
         )
 
         return res.modified_count == 1
-    
+
     def set_metadata(self, *, blueprint_id: str, metadata: Dict[str, Any]) -> bool:
         """Set the metadata dictionary for a blueprint document."""
         if not isinstance(metadata, dict):
@@ -81,6 +81,10 @@ class MongoBlueprintRepository(BlueprintRepository):
 
     def exists(self, blueprint_id: str) -> bool:
         return self._col.count_documents({"blueprint_id": blueprint_id}, limit=1) == 1
+
+    def find_by_name(self, user_id: str, name: str) -> BlueprintDocument | None:
+        raw = self._col.find_one({"user_id": user_id, "spec_dict.name": name})
+        return BlueprintDocument(**raw) if raw else None
 
     # --------- listing & counting with optional user filter -------
     def _user_q(self, user_id: str | None) -> Dict[str, Any]:

--- a/multi-agent/lib/mas/blueprints/exceptions.py
+++ b/multi-agent/lib/mas/blueprints/exceptions.py
@@ -41,3 +41,11 @@ class BlueprintMetadataError(BlueprintError):
         self.message = message or f"Failed to update metadata for blueprint '{blueprint_id}'"
         super().__init__(self.message)
 
+
+class BlueprintCloneError(BlueprintError):
+    """Raised when cloning a blueprint or its resources fails."""
+    def __init__(self, message: str, cause: Exception = None):
+        self.message = message
+        self.cause = cause
+        super().__init__(self.message)
+

--- a/multi-agent/lib/mas/blueprints/repository/repository.py
+++ b/multi-agent/lib/mas/blueprints/repository/repository.py
@@ -42,11 +42,6 @@ class BlueprintRepository(ABC):
     def load_many(self, blueprint_ids: List[str]) -> List[BlueprintDocument]:
         """Load multiple blueprint documents by their IDs in a single operation."""
 
-    # ────────────────────────────── Lookups ─────────────────────────────
-    @abstractmethod
-    def find_by_name(self, user_id: str, name: str) -> Optional["BlueprintDocument"]:
-        """Find a blueprint document by user and name, or return None."""
-
     # ────────────────────────────── Listings / Stats ────────────────────
     @abstractmethod
     def list_ids(

--- a/multi-agent/lib/mas/blueprints/repository/repository.py
+++ b/multi-agent/lib/mas/blueprints/repository/repository.py
@@ -17,7 +17,7 @@ class BlueprintRepository(ABC):
         """
         Replace an existing draft.  Return True if a document was modified.
         """
-        
+
     @abstractmethod
     def set_metadata(self, *, blueprint_id: str, metadata: Dict[str, Any]) -> bool:
         """
@@ -41,6 +41,11 @@ class BlueprintRepository(ABC):
     @abstractmethod
     def load_many(self, blueprint_ids: List[str]) -> List[BlueprintDocument]:
         """Load multiple blueprint documents by their IDs in a single operation."""
+
+    # ────────────────────────────── Lookups ─────────────────────────────
+    @abstractmethod
+    def find_by_name(self, user_id: str, name: str) -> Optional["BlueprintDocument"]:
+        """Find a blueprint document by user and name, or return None."""
 
     # ────────────────────────────── Listings / Stats ────────────────────
     @abstractmethod

--- a/multi-agent/lib/mas/sharing/cloner.py
+++ b/multi-agent/lib/mas/sharing/cloner.py
@@ -293,6 +293,19 @@ class ShareCloner:
         # Fallback to UUID if too many conflicts
         return f"{base_name} ({uuid4().hex[:8]})"
 
+    def _resolve_blueprint_name_conflict(self, user_id: str, preferred_name: str) -> str:
+        """Resolve blueprint name conflicts by adding copy suffix."""
+        base_name = preferred_name
+        current_name = f"{base_name} (copy)"
+
+        for counter in range(2, 101):
+            existing = self.blueprints._repo.find_by_name(user_id, current_name)
+            if not existing:
+                return current_name
+            current_name = f"{base_name} (copy {counter})"
+
+        return f"{base_name} ({uuid4().hex[:8]})"
+
     def _clone_blueprint_draft(self, draft: BlueprintDraft, rid_mapping: Dict[str, str],
                                ctx: CloneContext) -> BlueprintDraft:
         """Clone a BlueprintDraft with proper ref replacement and new step UIDs."""
@@ -308,7 +321,9 @@ class ShareCloner:
 
         is_self_clone = ctx.sender_user_id == ctx.recipient_user_id
         if is_self_clone:
-            new_name = f"{draft.name} (copy)"
+            new_name = self._resolve_blueprint_name_conflict(
+                ctx.recipient_user_id, draft.name
+            )
         else:
             new_name = f"{draft.name} (from {ctx.sender_user_id})"
 

--- a/multi-agent/lib/mas/sharing/cloner.py
+++ b/multi-agent/lib/mas/sharing/cloner.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from mas.resources.models import Resource
 from mas.resources.registry import ResourcesRegistry
 from mas.blueprints.models.blueprint import BlueprintDraft, BlueprintResource, StepDef
+from mas.blueprints.exceptions import BlueprintAccessDeniedError, BlueprintCloneError
 from mas.blueprints.service import BlueprintService
 from mas.catalog.element_registry import ElementRegistry
 from mas.core.ref import RefWalker, RefRemapper
@@ -84,7 +85,7 @@ class ShareCloner:
         result = self._clone_resource_set(closure_data, ctx)
 
         if not result.success:
-            raise ValueError(f"Resource cloning failed: {result.errors}")
+            raise BlueprintCloneError(f"Resource cloning failed: {result.errors}")
 
         logger.info(f"Resource graph clone completed: {result.resources_cloned} resources cloned")
         return result.rid_mapping, result.name_conflicts
@@ -97,7 +98,7 @@ class ShareCloner:
             # Load and validate blueprint
             bp_doc = self.blueprints.get_blueprint_draft_doc(blueprint_id)
             if bp_doc.user_id != ctx.sender_user_id:
-                raise ValueError(f"Blueprint {blueprint_id} not owned by sender")
+                raise BlueprintAccessDeniedError(blueprint_id, ctx.sender_user_id)
 
             draft = BlueprintDraft(**bp_doc.spec_dict)
 
@@ -142,7 +143,7 @@ class ShareCloner:
         clone_result = self._clone_resource_set(closure_data, ctx)
 
         if not clone_result.success:
-            raise ValueError(f"Failed to clone resources: {clone_result.errors}")
+            raise BlueprintCloneError(f"Failed to clone resources: {clone_result.errors}")
 
         logger.debug(f"RID mapping created: {clone_result.rid_mapping}")
         return clone_result.rid_mapping, clone_result.name_conflicts, clone_result.resources_cloned

--- a/multi-agent/lib/mas/sharing/cloner.py
+++ b/multi-agent/lib/mas/sharing/cloner.py
@@ -294,6 +294,23 @@ class ShareCloner:
         # Fallback to UUID if too many conflicts
         return f"{base_name} ({uuid4().hex[:8]})"
 
+    def _resolve_blueprint_name_conflict(self, original_name: str, ctx: CloneContext) -> str:
+        """Resolve blueprint name conflicts for self-duplication: (copy), (copy 2), etc."""
+        existing_names = {
+            s.name for s in self.blueprints.list_summaries(user_id=ctx.recipient_user_id)
+        }
+
+        candidate = f"{original_name} (copy)"
+        if candidate not in existing_names:
+            return candidate
+
+        for counter in range(2, 101):
+            candidate = f"{original_name} (copy {counter})"
+            if candidate not in existing_names:
+                return candidate
+
+        return f"{original_name} (copy {uuid4().hex[:8]})"
+
     def _clone_blueprint_draft(self, draft: BlueprintDraft, rid_mapping: Dict[str, str],
                                ctx: CloneContext) -> BlueprintDraft:
         """Clone a BlueprintDraft with proper ref replacement and new step UIDs."""
@@ -309,7 +326,7 @@ class ShareCloner:
 
         is_self_clone = ctx.sender_user_id == ctx.recipient_user_id
         if is_self_clone:
-            clone_name = f"{draft.name} (copy)"
+            clone_name = self._resolve_blueprint_name_conflict(draft.name, ctx)
         else:
             clone_name = f"{draft.name} (from {ctx.sender_user_id})"
 

--- a/multi-agent/lib/mas/sharing/cloner.py
+++ b/multi-agent/lib/mas/sharing/cloner.py
@@ -293,19 +293,6 @@ class ShareCloner:
         # Fallback to UUID if too many conflicts
         return f"{base_name} ({uuid4().hex[:8]})"
 
-    def _resolve_blueprint_name_conflict(self, user_id: str, preferred_name: str) -> str:
-        """Resolve blueprint name conflicts by adding copy suffix."""
-        base_name = preferred_name
-        current_name = f"{base_name} (copy)"
-
-        for counter in range(2, 101):
-            existing = self.blueprints._repo.find_by_name(user_id, current_name)
-            if not existing:
-                return current_name
-            current_name = f"{base_name} (copy {counter})"
-
-        return f"{base_name} ({uuid4().hex[:8]})"
-
     def _clone_blueprint_draft(self, draft: BlueprintDraft, rid_mapping: Dict[str, str],
                                ctx: CloneContext) -> BlueprintDraft:
         """Clone a BlueprintDraft with proper ref replacement and new step UIDs."""
@@ -321,15 +308,13 @@ class ShareCloner:
 
         is_self_clone = ctx.sender_user_id == ctx.recipient_user_id
         if is_self_clone:
-            new_name = self._resolve_blueprint_name_conflict(
-                ctx.recipient_user_id, draft.name
-            )
+            clone_name = f"{draft.name} (copy)"
         else:
-            new_name = f"{draft.name} (from {ctx.sender_user_id})"
+            clone_name = f"{draft.name} (from {ctx.sender_user_id})"
 
         return BlueprintDraft(
             plan=self._clone_plan(draft.plan, rid_mapping),
-            name=new_name,
+            name=clone_name,
             description=draft.description,
             **resource_fields
         )

--- a/multi-agent/lib/mas/sharing/cloner.py
+++ b/multi-agent/lib/mas/sharing/cloner.py
@@ -306,9 +306,15 @@ class ShareCloner:
             for category in ResourceCategory
         }
 
+        is_self_clone = ctx.sender_user_id == ctx.recipient_user_id
+        if is_self_clone:
+            new_name = f"{draft.name} (copy)"
+        else:
+            new_name = f"{draft.name} (from {ctx.sender_user_id})"
+
         return BlueprintDraft(
             plan=self._clone_plan(draft.plan, rid_mapping),
-            name=f"{draft.name} (from {ctx.sender_user_id})",
+            name=new_name,
             description=draft.description,
             **resource_fields
         )

--- a/multi-agent/lib/mas/sharing/service.py
+++ b/multi-agent/lib/mas/sharing/service.py
@@ -94,6 +94,14 @@ class ShareService:
         except Exception as e:
             raise ValueError(f"Failed to accept share: {str(e)}")
 
+    def duplicate_blueprint(self, *, blueprint_id: str, user_id: str) -> tuple:
+        """Duplicate a blueprint for the same user (no invite created)."""
+        ctx = CloneContext(
+            sender_user_id=user_id,
+            recipient_user_id=user_id,
+        )
+        return self._cloner.clone_blueprint(blueprint_id=blueprint_id, ctx=ctx)
+
     def decline_invite(self, share_id: str, *, recipient_user_id: str) -> None:
         """Decline invitation."""
         invite = self._repo.get(share_id)

--- a/ui/client/src/api/blueprints.ts
+++ b/ui/client/src/api/blueprints.ts
@@ -170,6 +170,25 @@ export async function updateBlueprint(
 }
 
 // ────────────────────────────────────────────────────────────────────────────────
+// Blueprint Cloning
+// ────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Clone a blueprint and all its dependencies for the current user.
+ * Creates a new blueprint with "(copy)" suffix.
+ */
+export async function cloneBlueprint(
+  blueprintId: string,
+  userId: string
+): Promise<SaveBlueprintResponse> {
+  const { data } = await axios.post<SaveBlueprintResponse>('/blueprints/blueprint.clone', {
+    blueprintId,
+    userId,
+  });
+  return data;
+}
+
+// ────────────────────────────────────────────────────────────────────────────────
 // Blueprint Metadata & Sharing
 // ────────────────────────────────────────────────────────────────────────────────
 

--- a/ui/client/src/api/blueprints.ts
+++ b/ui/client/src/api/blueprints.ts
@@ -170,18 +170,18 @@ export async function updateBlueprint(
 }
 
 // ────────────────────────────────────────────────────────────────────────────────
-// Blueprint Cloning
+// Blueprint Duplication
 // ────────────────────────────────────────────────────────────────────────────────
 
 /**
- * Clone a blueprint and all its dependencies for the current user.
+ * Duplicate a blueprint and all its dependencies for the current user.
  * Creates a new blueprint with "(copy)" suffix.
  */
-export async function cloneBlueprint(
+export async function duplicateBlueprint(
   blueprintId: string,
   userId: string
 ): Promise<SaveBlueprintResponse> {
-  const { data } = await axios.post<SaveBlueprintResponse>('/blueprints/blueprint.clone', {
+  const { data } = await axios.post<SaveBlueprintResponse>('/blueprints/blueprint.duplicate', {
     blueprintId,
     userId,
   });

--- a/ui/client/src/components/agentic-ai/WorkflowsPanel.tsx
+++ b/ui/client/src/components/agentic-ai/WorkflowsPanel.tsx
@@ -17,7 +17,7 @@ import SimpleTooltip from "@/components/shared/SimpleTooltip";
 import { FlowObject } from "./graphs/interfaces";
 import GraphDisplay from "./graphs/GraphDisplay";
 import { fetchActiveSessions } from "@/api/agentic";
-import { fetchBlueprintSummaries, deleteBlueprint, fetchResolvedBlueprint, cloneBlueprint } from "@/api/blueprints";
+import { fetchBlueprintSummaries, deleteBlueprint, fetchResolvedBlueprint, duplicateBlueprint } from "@/api/blueprints";
 import { convertGraphFlowToFlowObject } from "@/utils/blueprintHelpers";
 import ShareWorkflow from "./ShareWorkflow";
 import { BlueprintValidationResult } from "@/types/validation";
@@ -63,8 +63,8 @@ export default function WorkflowsPanel({
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
   const [flowToDelete, setFlowToDelete] = useState<FlowObject | null>(null);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
-  const [isCloning, setIsCloning] = useState<string | null>(null);
-  const cloningInFlight = useRef<Set<string>>(new Set());
+  const [isDuplicating, setIsDuplicating] = useState<string | null>(null);
+  const duplicatingInFlight = useRef<Set<string>>(new Set());
   const [selectedBlueprintData, setSelectedBlueprintData] = useState<{
     specDict: any;
     sharingEnabled: boolean;
@@ -233,20 +233,20 @@ export default function WorkflowsPanel({
     });
   };
 
-  const handleCloneClick = async (flow: FlowObject, event: React.MouseEvent) => {
+  const handleDuplicateClick = async (flow: FlowObject, event: React.MouseEvent) => {
     event.stopPropagation();
-    if (cloningInFlight.current.has(flow.id)) return;
-    cloningInFlight.current.add(flow.id);
-    setIsCloning(flow.id);
+    if (duplicatingInFlight.current.has(flow.id)) return;
+    duplicatingInFlight.current.add(flow.id);
+    setIsDuplicating(flow.id);
     try {
       const userId = user?.username || "default";
-      await cloneBlueprint(flow.id, userId);
+      await duplicateBlueprint(flow.id, userId);
       await fetchAvailableFlows();
     } catch (error) {
-      console.error("Error cloning blueprint:", error);
+      console.error("Error duplicating blueprint:", error);
     } finally {
-      cloningInFlight.current.delete(flow.id);
-      setIsCloning(null);
+      duplicatingInFlight.current.delete(flow.id);
+      setIsDuplicating(null);
     }
   };
 
@@ -397,13 +397,13 @@ export default function WorkflowsPanel({
                           <Users className="h-3 w-3" />
                         </Button>
                       </SimpleTooltip>
-                      <SimpleTooltip content={<p>Clone this workflow</p>}>
+                      <SimpleTooltip content={<p>Duplicate this workflow</p>}>
                         <Button
                           variant="ghost"
                           size="sm"
                           className="h-6 w-6 p-0 hover:bg-green-500/20 hover:text-green-400"
-                          onClick={(e) => handleCloneClick(flow, e)}
-                          disabled={isCloning === flow.id}
+                          onClick={(e) => handleDuplicateClick(flow, e)}
+                          disabled={isDuplicating === flow.id}
                         >
                           <Copy className="h-3 w-3" />
                         </Button>

--- a/ui/client/src/components/agentic-ai/WorkflowsPanel.tsx
+++ b/ui/client/src/components/agentic-ai/WorkflowsPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { motion } from "framer-motion";
-import { Trash2, Users, Pencil, Search, X } from "lucide-react";
+import { Trash2, Users, Pencil, Search, X, Copy } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/contexts/AuthContext";
 import { useShared } from "@/contexts/SharedContext";
@@ -17,7 +17,7 @@ import SimpleTooltip from "@/components/shared/SimpleTooltip";
 import { FlowObject } from "./graphs/interfaces";
 import GraphDisplay from "./graphs/GraphDisplay";
 import { fetchActiveSessions } from "@/api/agentic";
-import { fetchBlueprintSummaries, deleteBlueprint, fetchResolvedBlueprint } from "@/api/blueprints";
+import { fetchBlueprintSummaries, deleteBlueprint, fetchResolvedBlueprint, cloneBlueprint } from "@/api/blueprints";
 import { convertGraphFlowToFlowObject } from "@/utils/blueprintHelpers";
 import ShareWorkflow from "./ShareWorkflow";
 import { BlueprintValidationResult } from "@/types/validation";
@@ -63,6 +63,7 @@ export default function WorkflowsPanel({
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false);
   const [flowToDelete, setFlowToDelete] = useState<FlowObject | null>(null);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
+  const [isCloning, setIsCloning] = useState<string | null>(null);
   const [selectedBlueprintData, setSelectedBlueprintData] = useState<{
     specDict: any;
     sharingEnabled: boolean;
@@ -231,6 +232,20 @@ export default function WorkflowsPanel({
     });
   };
 
+  const handleCloneClick = async (flow: FlowObject, event: React.MouseEvent) => {
+    event.stopPropagation();
+    setIsCloning(flow.id);
+    try {
+      const userId = user?.username || "default";
+      await cloneBlueprint(flow.id, userId);
+      await fetchAvailableFlows();
+    } catch (error) {
+      console.error("Error cloning blueprint:", error);
+    } finally {
+      setIsCloning(null);
+    }
+  };
+
   const handleDeleteConfirm = async () => {
     if (!flowToDelete) return;
 
@@ -376,6 +391,17 @@ export default function WorkflowsPanel({
                           onClick={(e) => handleShareClick(flow, e)}
                         >
                           <Users className="h-3 w-3" />
+                        </Button>
+                      </SimpleTooltip>
+                      <SimpleTooltip content={<p>Clone this workflow</p>}>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 w-6 p-0 hover:bg-green-500/20 hover:text-green-400"
+                          onClick={(e) => handleCloneClick(flow, e)}
+                          disabled={isCloning === flow.id}
+                        >
+                          <Copy className="h-3 w-3" />
                         </Button>
                       </SimpleTooltip>
                       {showDeleteButton && (

--- a/ui/client/src/components/agentic-ai/WorkflowsPanel.tsx
+++ b/ui/client/src/components/agentic-ai/WorkflowsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { motion } from "framer-motion";
 import { Trash2, Users, Pencil, Search, X, Copy } from "lucide-react";
 import { Input } from "@/components/ui/input";
@@ -64,6 +64,7 @@ export default function WorkflowsPanel({
   const [flowToDelete, setFlowToDelete] = useState<FlowObject | null>(null);
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
   const [isCloning, setIsCloning] = useState<string | null>(null);
+  const cloningInFlight = useRef<Set<string>>(new Set());
   const [selectedBlueprintData, setSelectedBlueprintData] = useState<{
     specDict: any;
     sharingEnabled: boolean;
@@ -234,6 +235,8 @@ export default function WorkflowsPanel({
 
   const handleCloneClick = async (flow: FlowObject, event: React.MouseEvent) => {
     event.stopPropagation();
+    if (cloningInFlight.current.has(flow.id)) return;
+    cloningInFlight.current.add(flow.id);
     setIsCloning(flow.id);
     try {
       const userId = user?.username || "default";
@@ -242,6 +245,7 @@ export default function WorkflowsPanel({
     } catch (error) {
       console.error("Error cloning blueprint:", error);
     } finally {
+      cloningInFlight.current.delete(flow.id);
       setIsCloning(null);
     }
   };


### PR DESCRIPTION
## Summary
  - Adds a Clone button next to Share/Edit/Delete in the workflows list
  - Reuses the existing ShareCloner.clone_blueprint() with sender==recipient
  - Cloned workflow gets '(copy)' suffix, all resources and step UIDs are regenerated

  ## Changes
  - **multi-agent/api/flask/endpoints/blueprints.py** - New POST /blueprint.clone endpoint
  - **multi-agent/sharing/cloner.py** - Smart naming: '(copy)' for self-clone, '(from
  user)' for sharing
  - **ui/client/src/api/blueprints.ts** - New cloneBlueprint() API function
  - **ui/client/src/components/agentic-ai/WorkflowsPanel.tsx** - Clone button + handler

  ## How it works
  The existing ShareCloner already handles blueprint cloning with full dependency
  resolution, RID remapping, and step UID regeneration. For 'clone to self', we simply
  call it with sender_user_id == recipient_user_id.

  4 files changed, ~92 insertions, ~5 deletions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added blueprint cloning capability, enabling users to quickly duplicate workflows along with all associated dependencies and configurations.
  * Introduced Clone button in the workflow interface with comprehensive state management and error handling for reliable cloning operations.
  * Built-in operation tracking prevents accidental duplicate clone submissions during concurrent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->