### PR TITLE
Genie 1014/story/rputer default part orch

### DIFF
--- a/multi-agent/lib/mas/elements/conditions/router_direct/spec/spec.py
+++ b/multi-agent/lib/mas/elements/conditions/router_direct/spec/spec.py
@@ -4,6 +4,7 @@ from ..router_condition_factory import RouterDirectConditionFactory
 from ..router import RouterDirectCondition
 from ..identifiers import Identifier, META
 from mas.core.enums import ResourceCategory
+from mas.core.field_hints import HiddenHint
 from typing import ClassVar
 
 
@@ -18,3 +19,4 @@ class RouterDirectConditionElementSpec(BaseElementSpec):
     reads = RouterDirectCondition.READS
     tags = META.tags
     output_schema = RouterDirectCondition.get_output_schema()
+    hints = [HiddenHint(reason="System-managed router condition").model_dump(mode="json")]

--- a/multi-agent/lib/mas/elements/nodes/orchestrator/config.py
+++ b/multi-agent/lib/mas/elements/nodes/orchestrator/config.py
@@ -3,7 +3,7 @@ from pydantic import Field
 from typing import Optional, List, Literal
 from .identifiers import Identifier
 from mas.core.ref.models import LLMRef, ToolRef
-from mas.core.field_hints import ApiHint, HintType, SelectionType
+from mas.core.field_hints import ApiHint, HiddenHint, HintType, SelectionType
 
 
 class OrchestratorNodeConfig(NodeBaseConfig):
@@ -39,4 +39,9 @@ class OrchestratorNodeConfig(NodeBaseConfig):
     max_rounds: int = Field(
         100,
         description="Maximum planning/execution rounds per orchestration cycle"
+    )
+    router_direct: bool = Field(
+        default=True,
+        description="Automatically attach a router_direct condition for graph routing",
+        json_schema_extra=HiddenHint(reason="System-managed routing flag").to_hints()
     )

--- a/multi-agent/lib/mas/graph/rt_graph_plan.py
+++ b/multi-agent/lib/mas/graph/rt_graph_plan.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import List, Dict, Optional, Iterator, Any
 from mas.session.domain.session_registry import SessionRegistry
 from mas.core.element_card_builder import ElementCardBuilder
@@ -138,15 +139,17 @@ class RTGraphPlan:
 
         # ------------------------------------------------------------------ #
         # 3. Bind node & condition callables + inject context
+        # Deep-copy each instance so that multiple steps sharing the same
+        # rid get independent objects (prevents set_context overwrites).
         # ------------------------------------------------------------------ #
 
-        node_func = self._session.get_instance(ResourceCategory.NODE, step.rid)
+        node_func = deepcopy(self._session.get_instance(ResourceCategory.NODE, step.rid))
         if hasattr(node_func, "set_context"):
             node_func.set_context(step_context)
 
         condition_func = None
         if step.condition:
-            condition_func = self._session.get_instance(ResourceCategory.CONDITION, step.condition.rid)
+            condition_func = deepcopy(self._session.get_instance(ResourceCategory.CONDITION, step.condition.rid))
             if hasattr(condition_func, "set_context"):
                 condition_func.set_context(step_context)
 

--- a/multi-agent/lib/mas/graph/validation/orchestrator/checker.py
+++ b/multi-agent/lib/mas/graph/validation/orchestrator/checker.py
@@ -278,24 +278,8 @@ class OrchestratorPatternChecker:
         Uses FinalizerAnalyzer to identify finalization nodes.
         """
         if not orch.branches:
-            # No branches at all - definitely missing finalize
-            issue = OrchestratorIssue(
-                issue_type=OrchestratorIssueType.MISSING_FINALIZE,
-                orchestrator_uid=orch.uid,
-                related_node_uid=None,
-                description=f"Top-level orchestrator '{orch.uid}' has no branches (needs finalize path)"
-            )
-            issues.append(issue)
-            
-            messages.append(ValidationMessage(
-                text=f"Top-level orchestrator '{orch.uid}' has no branches - needs completion strategy",
-                severity=MessageSeverity.ERROR,
-                code=MessageCode.ORCHESTRATOR_MISSING_FINALIZE,
-                context={
-                    "orchestrator_uid": orch.uid,
-                    "fix": "Add branch to final_answer_node or terminal node"
-                }
-            ))
+            # No branches yet — router may be auto-attached but edges not drawn.
+            # Skip; branches will be validated once the user connects edges.
             return
         
         # Check if any branch leads to finalization

--- a/ui/client/src/hooks/use-graph-logic.ts
+++ b/ui/client/src/hooks/use-graph-logic.ts
@@ -658,16 +658,19 @@ export const useGraphLogic = (options: UseGraphLogicOptions = {}) => {
       // Comment out connection feasibility check for now
       // if (isConnectionFeasible(params)) {
 
-      // Check if source node has a condition attached
+      // Check if source node has a condition attached or uses router_direct
       const sourceNode = nodes.find((node) => node.id === params.source);
       const hasCondition =
         sourceNode?.data?.referencedConditions &&
         sourceNode.data.referencedConditions.length > 0;
+      const isRouterDirect =
+        sourceNode?.data?.workspaceData?.config?.router_direct === true;
 
-      if (hasCondition) {
-        // Get condition type and existing branches
-        const condition = sourceNode.data.referencedConditions[0];
-        const conditionType = condition.workspaceData?.type || condition.type;
+      if (hasCondition || isRouterDirect) {
+        const condition = hasCondition ? sourceNode.data.referencedConditions[0] : null;
+        const conditionType = condition
+          ? condition.workspaceData?.type || condition.type
+          : "router_direct";
 
         // Get existing edges from this source to determine existing branches
         const existingEdges = edges.filter(
@@ -1135,21 +1138,17 @@ export const useGraphLogic = (options: UseGraphLogicOptions = {}) => {
     setYamlFlow((prevFlow) => {
       const sourceNode = nodes.find((node) => node.id === params.source);
       const condition = sourceNode?.data?.referencedConditions?.[0];
+      const isRouterDirect =
+        sourceNode?.data?.workspaceData?.config?.router_direct === true;
 
       const updatedPlan = prevFlow.plan.map((step) => {
-        if (step.uid === params.source && condition) {
-          // Get existing branches or initialize empty object
+        if (step.uid === params.source && (condition || isRouterDirect)) {
           const existingBranches = step.branches || {};
-
-          // Add new branch mapping based on condition type
           let newBranches = { ...existingBranches };
 
           if (branchConfig.conditionType === "router_direct") {
-            // For direct routing, map direct output to target step
             newBranches[params.target!] = params.target!;
           } else if (branchConfig.conditionType === "router_boolean") {
-            // For symbolic routing, map symbolic output to target step
-            // Convert boolean values to actual booleans for router_boolean
             let branchKey =
               branchConfig.branch === "true"
                 ? true
@@ -1161,30 +1160,48 @@ export const useGraphLogic = (options: UseGraphLogicOptions = {}) => {
 
           return {
             ...step,
-            exit_condition: condition.workspaceData?.rid || condition.id,
+            exit_condition: condition
+              ? condition.workspaceData?.rid || condition.id
+              : "router_direct",
             branches: newBranches,
           };
         }
         return step;
       });
 
-      // Add condition definition if not exists
-      const conditionRid = condition?.workspaceData?.rid || condition?.id;
-      const conditionExists = (prevFlow.conditions || []).some(
-        (cond) => cond.rid === `$ref:${conditionRid}`,
-      );
-
       let updatedConditions = prevFlow.conditions || [];
-      if (condition && !conditionExists) {
-        updatedConditions = [
-          ...updatedConditions,
-          {
-            rid: `$ref:${conditionRid}`,
-            name: condition.workspaceData?.name || condition.label,
-            type: condition.workspaceData?.type,
-            config: condition.workspaceData?.config,
-          },
-        ];
+
+      if (condition) {
+        const conditionRid = condition.workspaceData?.rid || condition.id;
+        const conditionExists = updatedConditions.some(
+          (cond) => cond.rid === `$ref:${conditionRid}`,
+        );
+        if (!conditionExists) {
+          updatedConditions = [
+            ...updatedConditions,
+            {
+              rid: `$ref:${conditionRid}`,
+              name: condition.workspaceData?.name || condition.label,
+              type: condition.workspaceData?.type,
+              config: condition.workspaceData?.config,
+            },
+          ];
+        }
+      } else if (isRouterDirect) {
+        const rdExists = updatedConditions.some(
+          (cond) => cond.rid === "router_direct",
+        );
+        if (!rdExists) {
+          updatedConditions = [
+            ...updatedConditions,
+            {
+              rid: "router_direct",
+              name: "Router Direct",
+              type: "router_direct",
+              config: { type: "router_direct" },
+            },
+          ];
+        }
       }
 
       return {

--- a/ui/client/src/workspace/BuildingBlocksSidebar.tsx
+++ b/ui/client/src/workspace/BuildingBlocksSidebar.tsx
@@ -1,27 +1,22 @@
 import React, { useState, useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Eye, Loader2 } from "lucide-react";
 import { BuildingBlock } from "@/types/graph";
 import { getCategoryDisplay } from "@/components/shared/helpers";
 import ResourceDetailsModal from "./ResourceDetailsModal";
-import { UmamiTrack } from '@/components/ui/umamitrack';
-import { UmamiEvents } from '@/config/umamiEvents';
 import { useTheme } from "@/contexts/ThemeContext";
 import { deriveThemeColors } from "@/lib/colorUtils";
 
 interface BuildingBlocksSidebarProps {
   buildingBlocks: BuildingBlock[];
-  conditions: BuildingBlock[];
   isLoading: boolean;
   onDragStart: (event: React.DragEvent, block: BuildingBlock) => void;
-  usedElementIds?: Set<string>; // Track which elements are currently used on canvas
+  usedElementIds?: Set<string>;
 }
 
 const BuildingBlocksSidebar: React.FC<BuildingBlocksSidebarProps> = ({
   buildingBlocks,
-  conditions,
   isLoading,
   onDragStart,
   usedElementIds = new Set<string>(),
@@ -32,14 +27,10 @@ const BuildingBlocksSidebar: React.FC<BuildingBlocksSidebarProps> = ({
   const [isDetailsModalOpen, setIsDetailsModalOpen] = useState(false);
   const { primaryHex } = useTheme();
 
-  // Derive theme-aligned colors from the single shared helper
   const themeColors = useMemo(() => {
     const t = deriveThemeColors(primaryHex);
     return {
       iconBg: t.primary,
-      conditionBg: t.conditionAccent,
-      conditionCardBg: t.conditionCardBg,
-      conditionCardBorder: t.conditionCardBorder,
     };
   }, [primaryHex]);
 
@@ -49,7 +40,6 @@ const BuildingBlocksSidebar: React.FC<BuildingBlocksSidebarProps> = ({
   };
 
   const handleDragStart = (event: React.DragEvent, block: BuildingBlock) => {
-    // Prevent dragging if element is already used
     if (usedElementIds.has(block.id)) {
       event.preventDefault();
       return;
@@ -61,157 +51,72 @@ const BuildingBlocksSidebar: React.FC<BuildingBlocksSidebarProps> = ({
     <div className="w-80 h-full">
       <Card className="bg-background-card shadow-card border-gray-800 h-full flex flex-col">
         <CardHeader className="py-3 px-6 border-b border-gray-800">
-          <CardTitle className="text-lg font-heading">Elements</CardTitle>
+          <CardTitle className="text-lg font-heading">Nodes</CardTitle>
         </CardHeader>
         <CardContent className="p-4 flex-1 overflow-hidden flex flex-col">
           <div className="flex-1 min-h-0">
-            <Tabs defaultValue="nodes" className="h-full flex flex-col">
-              <TabsList className="grid w-full grid-cols-2 bg-gray-800">
-                <TabsTrigger value="nodes" className="text-gray-300 data-[state=active]:text-white">
-                  Nodes ({buildingBlocks.length})
-                </TabsTrigger>
-
-                <UmamiTrack event={UmamiEvents.AGENT_GRAPHS_CONDITIONS_BUTTON} includeUserData={false}>
-                  <TabsTrigger value="conditions" className="text-gray-300 data-[state=active]:text-white">
-                    Conditions ({conditions.length})
-                  </TabsTrigger>
-                </UmamiTrack>
-              </TabsList>
-
-              <TabsContent value="nodes" className="mt-4">
-                {isLoading ? (
-                  <div className="flex items-center justify-center h-32">
-                    <Loader2 className="h-8 w-8 animate-spin text-primary" />
-                    <span className="ml-2 text-sm text-gray-400">
-                      Loading blocks...
-                    </span>
-                  </div>
-                ) : (
-                  <div className="space-y-2 overflow-y-auto" style={{ maxHeight: 'calc(100vh - 430px)' }}>
-                    {buildingBlocks.map((block) => {
-                      const isUsed = usedElementIds.has(block.id);
-                      return (
-                        <Card
-                          key={block.id}
-                          className={`transition-colors ${
-                            isUsed
-                              ? 'bg-gray-900 border-gray-800 opacity-50 cursor-not-allowed'
-                              : 'bg-gray-800 border-gray-700 hover:border-gray-600 cursor-grab active:cursor-grabbing'
-                          }`}
-                          draggable={!isUsed}
-                          onDragStart={(event) => handleDragStart(event, block)}
-                        >
-                        <CardContent className="p-3">
-                          <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-2 flex-1">
-                              <div className="flex items-center justify-center w-8 h-8 rounded-full text-xs font-semibold text-white"
-                                   style={{ backgroundColor: themeColors.iconBg }}>
-                                {getCategoryDisplay(block.workspaceData?.category || "default").icon}
-                              </div>
-                              <div className="flex-1 min-w-0">
-                                <div className="flex items-center gap-2">
-                                  <h4 className={`font-medium text-sm truncate ${isUsed ? 'text-gray-500' : 'text-white'}`}>
-                                    {block.label}
-                                  </h4>
-                                  {isUsed && (
-                                    <span className="text-xs bg-gray-700 text-gray-300 px-1.5 py-0.5 rounded">
-                                      Used
-                                    </span>
-                                  )}
-                                </div>
-                                <p className="text-xs text-gray-400 truncate">
-                                  {block.workspaceData?.type || block.type}
-                                </p>
-                              </div>
-                            </div>
-                            {block.workspaceData && (
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                className="h-8 w-8 p-0 text-gray-400 hover:text-white"
-                                onClick={() => handleViewDetails(block)}
-                              >
-                                <Eye className="h-4 w-4" />
-                              </Button>
-                            )}
+            {isLoading ? (
+              <div className="flex items-center justify-center h-32">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+                <span className="ml-2 text-sm text-gray-400">
+                  Loading blocks...
+                </span>
+              </div>
+            ) : (
+              <div className="space-y-2 overflow-y-auto" style={{ maxHeight: 'calc(100vh - 350px)' }}>
+                {buildingBlocks.map((block) => {
+                  const isUsed = usedElementIds.has(block.id);
+                  return (
+                    <Card
+                      key={block.id}
+                      className={`transition-colors ${
+                        isUsed
+                          ? 'bg-gray-900 border-gray-800 opacity-50 cursor-not-allowed'
+                          : 'bg-gray-800 border-gray-700 hover:border-gray-600 cursor-grab active:cursor-grabbing'
+                      }`}
+                      draggable={!isUsed}
+                      onDragStart={(event) => handleDragStart(event, block)}
+                    >
+                    <CardContent className="p-3">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2 flex-1">
+                          <div className="flex items-center justify-center w-8 h-8 rounded-full text-xs font-semibold text-white"
+                               style={{ backgroundColor: themeColors.iconBg }}>
+                            {getCategoryDisplay(block.workspaceData?.category || "default").icon}
                           </div>
-                        </CardContent>
-                      </Card>
-                      );
-                    })}
-                  </div>
-                )}
-              </TabsContent>
-
-              <TabsContent value="conditions" className="mt-4">
-                {isLoading ? (
-                  <div className="flex items-center justify-center h-32">
-                    <Loader2 className="h-8 w-8 animate-spin text-primary" />
-                    <span className="ml-2 text-sm text-gray-400">
-                      Loading conditions...
-                    </span>
-                  </div>
-                ) : (
-                  <div className="space-y-2 overflow-y-auto" style={{ maxHeight: 'calc(100vh - 430px)' }}>
-                    {conditions.map((condition) => {
-                      const isUsed = usedElementIds.has(condition.id);
-                      return (
-                        <Card
-                          key={condition.id}
-                          className={`transition-colors ${
-                            isUsed
-                              ? 'bg-gray-900 border-gray-800 opacity-50 cursor-not-allowed'
-                              : 'cursor-grab active:cursor-grabbing'
-                          }`}
-                          style={{
-                            backgroundColor: isUsed ? undefined : themeColors.conditionCardBg,
-                            borderColor: isUsed ? undefined : themeColors.conditionCardBorder,
-                          }}
-                          draggable={!isUsed}
-                          onDragStart={(event) => handleDragStart(event, condition)}
-                        >
-                        <CardContent className="p-3">
-                          <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-2 flex-1">
-                              <div className="flex items-center justify-center w-8 h-8 rounded-full text-xs font-semibold text-white"
-                                   style={{ backgroundColor: themeColors.conditionBg }}>
-                                {getCategoryDisplay("conditions").icon}
-                              </div>
-                              <div className="flex-1 min-w-0">
-                                <div className="flex items-center gap-2">
-                                  <h4 className={`font-medium text-sm truncate ${isUsed ? 'text-gray-500' : 'text-white'}`}>
-                                    {condition.label}
-                                  </h4>
-                                  {isUsed && (
-                                    <span className="text-xs bg-gray-700 text-gray-300 px-1.5 py-0.5 rounded">
-                                      Used
-                                    </span>
-                                  )}
-                                </div>
-                                <p className="text-xs text-gray-400 truncate">
-                                  {condition.workspaceData?.type || condition.type}
-                                </p>
-                              </div>
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                              <h4 className={`font-medium text-sm truncate ${isUsed ? 'text-gray-500' : 'text-white'}`}>
+                                {block.label}
+                              </h4>
+                              {isUsed && (
+                                <span className="text-xs bg-gray-700 text-gray-300 px-1.5 py-0.5 rounded">
+                                  Used
+                                </span>
+                              )}
                             </div>
-                            {condition.workspaceData && (
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                className="h-8 w-8 p-0 text-gray-400 hover:text-white"
-                                onClick={() => handleViewDetails(condition)}
-                              >
-                                <Eye className="h-4 w-4" />
-                              </Button>
-                            )}
+                            <p className="text-xs text-gray-400 truncate">
+                              {block.workspaceData?.type || block.type}
+                            </p>
                           </div>
-                        </CardContent>
-                      </Card>
-                      );
-                    })}
-                  </div>
-                )}
-              </TabsContent>
-            </Tabs>
+                        </div>
+                        {block.workspaceData && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 w-8 p-0 text-gray-400 hover:text-white"
+                            onClick={() => handleViewDetails(block)}
+                          >
+                            <Eye className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                  );
+                })}
+              </div>
+            )}
           </div>
 
           {/* Fixed Instructions Footer */}
@@ -221,8 +126,6 @@ const BuildingBlocksSidebar: React.FC<BuildingBlocksSidebarProps> = ({
               <div className="text-xs text-gray-400 space-y-1">
                 <p>• Drag nodes from sidebar to canvas</p>
                 <p>• Connect nodes to build workflow</p>
-                <p>• Drag conditions onto nodes for branching</p>
-                <p>• Each node supports only one condition</p>
                 <p>• Always start with User Input node</p>
                 <p>• End workflow with Final Answer node</p>
               </div>

--- a/ui/client/src/workspace/NewGraph.tsx
+++ b/ui/client/src/workspace/NewGraph.tsx
@@ -17,8 +17,6 @@ export default function NewGraph({ onBack }: NewGraphProps) {
     nodes,
     edges,
     buildingBlocksData,
-    conditionsData,
-    allBlocksData,
     isLoadingBlocks,
     yamlFlow,
     handleNodesChange,
@@ -49,33 +47,18 @@ export default function NewGraph({ onBack }: NewGraphProps) {
     const usedIds = new Set<string>();
     
     nodes.forEach(node => {
-      // 1. Track the node itself by workspaceData.rid
       if (node.data?.workspaceData?.rid) {
-        const matchingBlock = [...buildingBlocksData, ...conditionsData].find(
+        const matchingBlock = buildingBlocksData.find(
           block => block.workspaceData?.rid === node.data.workspaceData?.rid
         );
         if (matchingBlock) {
           usedIds.add(matchingBlock.id);
         }
       }
-      
-      // 2. Track any conditions attached to this node
-      if (node.data?.referencedConditions && Array.isArray(node.data.referencedConditions)) {
-        node.data.referencedConditions.forEach((condition: any) => {
-          if (condition.workspaceData?.rid) {
-            const matchingCondition = conditionsData.find(
-              block => block.workspaceData?.rid === condition.workspaceData.rid
-            );
-            if (matchingCondition) {
-              usedIds.add(matchingCondition.id);
-            }
-          }
-        });
-      }
     });
     
     return usedIds;
-  }, [nodes, buildingBlocksData, conditionsData]);
+  }, [nodes, buildingBlocksData]);
 
   const handleSaveGraph = async () => {
     setSaveModalOpen(true);
@@ -91,7 +74,6 @@ export default function NewGraph({ onBack }: NewGraphProps) {
       <div className="w-80 h-full">
         <BuildingBlocksSidebar
           buildingBlocks={buildingBlocksData}
-          conditions={conditionsData}
           isLoading={isLoadingBlocks}
           onDragStart={onDragStart}
           usedElementIds={usedElementIds}


### PR DESCRIPTION
## Make Router Direct a Default Part of the Orchestrator

### Summary

Previously, to build a workflow with an orchestrator, users had to manually find the `router_direct` condition in the sidebar's "Conditions" tab, drag it onto the orchestrator node, and then draw branch edges. This PR makes the `router_direct` condition an automatic, system-managed part of the orchestrator — when a user draws an edge from an orchestrator node, it's automatically treated as a branch edge with direct routing. No manual condition attachment required.

### How the Solution Works

The orchestrator's config now carries a `router_direct: true` flag (hidden from the UI form). On the **backend**, the config schema was updated to accept this flag, the `router_direct` condition spec was fixed so it registers correctly in the `ElementRegistry`, and validation was relaxed so orchestrators without edges yet don't fail. On the **frontend**, the UI detects the `router_direct` flag on the node's config when drawing edges and automatically creates branch edges, injecting an inline `router_direct` condition definition into the YAML draft — producing the same YAML structure as existing fixtures. No auto-injection logic was added to the backend resolver or plan builder; the UI generates the full blueprint directly.

### File-by-File Changes

#### Backend (`multi-agent`)

| File | Change |
|------|--------|
| `elements/nodes/orchestrator/config.py` | Added `router_direct: bool = True` field to `OrchestratorNodeConfig` with `HiddenHint` so it's accepted by Pydantic but hidden from the UI form. This is the signal the UI reads to determine routing behavior. |
| `elements/conditions/router_direct/spec/spec.py` | Added missing `HiddenHint` import and `hints = [HiddenHint(...)]` to mark the condition as hidden in the catalog. Without the import, the spec module failed silently during auto-discovery and the condition was never registered in the `ElementRegistry`. |
| `graph/validation/orchestrator/checker.py` | Relaxed Rule 3 (missing finalize check): orchestrators with no branches yet now skip validation instead of erroring. Since the router is auto-attached, the orchestrator may exist on the canvas before any edges are drawn. |
| `graph/rt_graph_plan.py` | Deep-copy node and condition instances when creating runtime steps, so multiple steps sharing the same resource ID get independent objects (prevents `set_context` overwrites). |

#### Frontend (`ui/client`)

| File | Change |
|------|--------|
| `hooks/use-graph-logic.ts` | **`onConnect`**: Added `isRouterDirect` check — if the source node's config has `router_direct === true`, the branch modal opens with `conditionType: "router_direct"` (no explicit condition needed in `referencedConditions`). **`createConditionalEdge`**: For orchestrator nodes, sets `exit_condition: "router_direct"` on the step and adds a shared inline `router_direct` condition definition to the YAML conditions array (deduplicated). For non-orchestrator nodes with explicit conditions, behavior is unchanged. |
| `workspace/BuildingBlocksSidebar.tsx` | Removed the "Conditions" tab entirely. The sidebar now only shows "Nodes". Removed `conditions` prop, `Tabs`/`TabsContent` components, condition rendering, condition-related theme colors, and drag-drop instructions for conditions. |
| `workspace/NewGraph.tsx` | Removed `conditionsData` and `allBlocksData` from the graph hook. `usedElementIds` no longer tracks attached conditions. `BuildingBlocksSidebar` no longer receives the `conditions` prop. |