### PR TITLE
GENIE-1413/stickey-headers-for-categories-and-modals

### DIFF
--- a/ui/client/src/components/agentic-ai/graphs/GraphCreation.tsx
+++ b/ui/client/src/components/agentic-ai/graphs/GraphCreation.tsx
@@ -563,8 +563,8 @@ const GraphCreation: React.FC<GraphCreationProps> = ({
         <CardContent className="p-0 h-full relative">
           {/* YAML debug panel */}
           {showYamlDebug && yamlFlow && (
-            <div className="absolute top-4 right-4 z-50 bg-gray-900 border border-gray-700 rounded-lg p-4 max-w-md max-h-96 overflow-auto">
-              <div className="flex justify-between items-center mb-2">
+            <div className="absolute top-4 right-4 z-50 bg-gray-900 border border-gray-700 rounded-lg max-w-md max-h-96 flex flex-col overflow-hidden">
+              <div className="flex justify-between items-center px-4 pt-4 pb-2 flex-shrink-0 border-b border-gray-700">
                 <h3 className="text-sm font-medium text-white">
                   YAML Flow State
                 </h3>
@@ -577,7 +577,7 @@ const GraphCreation: React.FC<GraphCreationProps> = ({
                   <X className="w-4 h-4" />
                 </button>
               </div>
-              <pre className="text-xs text-gray-300 overflow-auto">
+              <pre className="text-xs text-gray-300 overflow-auto p-4 flex-1 min-h-0">
                 {yaml.dump(yamlFlow, { indent: 2, lineWidth: -1 })}
               </pre>
             </div>

--- a/ui/client/src/components/agentic-ai/workspace/ElementData.tsx
+++ b/ui/client/src/components/agentic-ai/workspace/ElementData.tsx
@@ -36,8 +36,8 @@ export const ElementData: React.FC<ElementDataProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-background-card border-gray-800 text-foreground max-w-2xl max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="bg-background-card border-gray-800 text-foreground max-w-2xl max-h-[80vh] flex flex-col overflow-hidden p-0 gap-0">
+        <DialogHeader className="px-6 pt-6 pb-4 flex-shrink-0 border-b border-gray-800">
           <DialogTitle className="flex items-center gap-2">
             <FileText className="h-5 w-5 text-primary" />
             {element?.name || `${elementType.name} Details`}
@@ -45,64 +45,66 @@ export const ElementData: React.FC<ElementDataProps> = ({
         </DialogHeader>
         
         {element && (
-          <div className="space-y-4">
-            {/* Basic Info */}
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="text-sm font-medium text-gray-400">Resource ID</label>
-                <p className="font-mono text-sm text-gray-300">{element.rid}</p>
+          <div className="flex-1 overflow-y-auto px-6 py-4 min-h-0">
+            <div className="space-y-4">
+              {/* Basic Info */}
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Resource ID</label>
+                  <p className="font-mono text-sm text-gray-300">{element.rid}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Type</label>
+                  <p className="text-sm text-gray-300">{element.type}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Version</label>
+                  <p className="text-sm text-gray-300">v{element.version || 1}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Category</label>
+                  <p className="text-sm text-gray-300">{element.category}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Created</label>
+                  <p className="text-sm text-gray-300">
+                    {element.created ? new Date(element.created).toLocaleString() : 'N/A'}
+                  </p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Last Updated</label>
+                  <p className="text-sm text-gray-300">
+                    {element.updated ? new Date(element.updated).toLocaleString() : 'N/A'}
+                  </p>
+                </div>
               </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Type</label>
-                <p className="text-sm text-gray-300">{element.type}</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Version</label>
-                <p className="text-sm text-gray-300">v{element.version || 1}</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Category</label>
-                <p className="text-sm text-gray-300">{element.category}</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Created</label>
-                <p className="text-sm text-gray-300">
-                  {element.created ? new Date(element.created).toLocaleString() : 'N/A'}
-                </p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Last Updated</label>
-                <p className="text-sm text-gray-300">
-                  {element.updated ? new Date(element.updated).toLocaleString() : 'N/A'}
-                </p>
-              </div>
+
+              {/* References */}
+              {resolvedNestedRefs && resolvedNestedRefs.length > 0 && (
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Referenced Resources</label>
+                  <div className="mt-1 space-y-1">
+                    {resolvedNestedRefs.map((ref, index) => (
+                      <Badge key={index} variant="outline" className="mr-2">
+                        {ref}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Configuration */}
+              {configWithResolvedRefs && (
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Full Configuration</label>
+                  <div className="mt-2 bg-gray-900 p-4 rounded-md">
+                    <pre className="text-xs text-gray-300 whitespace-pre-wrap overflow-x-auto">
+                      {JSON.stringify(maskSecretFieldsInConfig(configWithResolvedRefs, elementSchema?.config_schema), null, 2)}
+                    </pre>
+                  </div>
+                </div>
+              )}
             </div>
-
-            {/* References */}
-            {resolvedNestedRefs && resolvedNestedRefs.length > 0 && (
-              <div>
-                <label className="text-sm font-medium text-gray-400">Referenced Resources</label>
-                <div className="mt-1 space-y-1">
-                  {resolvedNestedRefs.map((ref, index) => (
-                    <Badge key={index} variant="outline" className="mr-2">
-                      {ref}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Configuration */}
-            {configWithResolvedRefs && (
-              <div>
-                <label className="text-sm font-medium text-gray-400">Full Configuration</label>
-                <div className="mt-2 bg-gray-900 p-4 rounded-md">
-                  <pre className="text-xs text-gray-300 whitespace-pre-wrap overflow-x-auto">
-                    {JSON.stringify(maskSecretFieldsInConfig(configWithResolvedRefs, elementSchema?.config_schema), null, 2)}
-                  </pre>
-                </div>
-              </div>
-            )}
           </div>
         )}
       </DialogContent>

--- a/ui/client/src/components/agentic-ai/workspace/ElementForm.tsx
+++ b/ui/client/src/components/agentic-ai/workspace/ElementForm.tsx
@@ -694,11 +694,11 @@ export const ElementForm: React.FC<ElementFormProps> = ({
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent
-        className="bg-background-card border-gray-800 text-foreground max-w-3xl max-h-[90vh] overflow-y-auto"
+        className="bg-background-card border-gray-800 text-foreground max-w-3xl max-h-[90vh] flex flex-col overflow-hidden p-0 gap-0"
         onInteractOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
       >
-        <DialogHeader>
+        <DialogHeader className="px-6 pt-6 pb-4 flex-shrink-0 border-b border-gray-800">
           <DialogTitle>
             {editingElement ? "Edit" : "Create"} {elementType.name}
           </DialogTitle>
@@ -710,61 +710,63 @@ export const ElementForm: React.FC<ElementFormProps> = ({
             e.preventDefault();
             handleSave();
           }}
-          className="space-y-4"
+          className="flex flex-col flex-1 min-h-0"
         >
-          {/* Render fields from combined schema */}
-          {Object.entries(elementSchema.config_schema.properties)
-            .filter(([fieldName, fieldSchema]) => {
-              // Always exclude category and type (handled by GUI)
-              if (['category', 'type'].includes(fieldName)) {
-                return false;
-              }
+          <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+            {/* Render fields from combined schema */}
+            {Object.entries(elementSchema.config_schema.properties)
+              .filter(([fieldName, fieldSchema]) => {
+                // Always exclude category and type (handled by GUI)
+                if (['category', 'type'].includes(fieldName)) {
+                  return false;
+                }
 
-              // Filter out hidden fields - check if field has hints.hidden.hint_type === "hidden"
-              if (fieldSchema?.hints?.hidden?.hint_type === "hidden") {
-                return false;
-              }
+                // Filter out hidden fields - check if field has hints.hidden.hint_type === "hidden"
+                if (fieldSchema?.hints?.hidden?.hint_type === "hidden") {
+                  return false;
+                }
 
-              // For both Create New and Edit mode: show only first-level required fields (name) + all cfg_dict fields
-              // Show first-level required fields (name is required from resource.schema)
-              const firstLevelRequiredFields = ['name'];
-              if (firstLevelRequiredFields.includes(fieldName)) {
-                return true;
-              }
+                // For both Create New and Edit mode: show only first-level required fields (name) + all cfg_dict fields
+                // Show first-level required fields (name is required from resource.schema)
+                const firstLevelRequiredFields = ['name'];
+                if (firstLevelRequiredFields.includes(fieldName)) {
+                  return true;
+                }
 
-              // Show all cfg_dict fields (element-specific config fields)
-              // These are fields that are NOT first-level fields from resource.schema
-              const firstLevelFields = ['name', 'category', 'type', 'cfg_dict', 'version', 'created', 'updated', 'nested_refs', 'rid', 'user_id'];
-              const isCfgDictField = !firstLevelFields.includes(fieldName);
-              return isCfgDictField;
+                // Show all cfg_dict fields (element-specific config fields)
+                // These are fields that are NOT first-level fields from resource.schema
+                const firstLevelFields = ['name', 'category', 'type', 'cfg_dict', 'version', 'created', 'updated', 'nested_refs', 'rid', 'user_id'];
+                const isCfgDictField = !firstLevelFields.includes(fieldName);
+                return isCfgDictField;
 
-              // Comment out the old edit mode logic that showed extra fields
-              // // For Edit mode: show all fields (except category/type)
-              // if (editingElement) {
-              //   return true;
-              // }
-            })
-            .sort(([fieldNameA, fieldSchemaA], [fieldNameB, fieldSchemaB]) => {
-              // Sort fields so that fields with dependencies come after their dependency fields
-              const populateHintA = fieldSchemaA?.hints?.action?.hint_type === 'populate' ? fieldSchemaA.hints.action : null;
-              const populateHintB = fieldSchemaB?.hints?.action?.hint_type === 'populate' ? fieldSchemaB.hints.action : null;
-              
-              // If A depends on B, A should come after B
-              if (populateHintA?.dependencies && Object.keys(populateHintA.dependencies).includes(fieldNameB)) {
-                return 1; // A comes after B
-              }
-              
-              // If B depends on A, B should come after A
-              if (populateHintB?.dependencies && Object.keys(populateHintB.dependencies).includes(fieldNameA)) {
-                return -1; // A comes before B
-              }
-              
-              // Otherwise, maintain original order
-              return 0;
-            })
-            .map(([fieldName, fieldSchema]) => renderFormField(fieldName, fieldSchema))}
+                // Comment out the old edit mode logic that showed extra fields
+                // // For Edit mode: show all fields (except category/type)
+                // if (editingElement) {
+                //   return true;
+                // }
+              })
+              .sort(([fieldNameA, fieldSchemaA], [fieldNameB, fieldSchemaB]) => {
+                // Sort fields so that fields with dependencies come after their dependency fields
+                const populateHintA = fieldSchemaA?.hints?.action?.hint_type === 'populate' ? fieldSchemaA.hints.action : null;
+                const populateHintB = fieldSchemaB?.hints?.action?.hint_type === 'populate' ? fieldSchemaB.hints.action : null;
+                
+                // If A depends on B, A should come after B
+                if (populateHintA?.dependencies && Object.keys(populateHintA.dependencies).includes(fieldNameB)) {
+                  return 1; // A comes after B
+                }
+                
+                // If B depends on A, B should come after A
+                if (populateHintB?.dependencies && Object.keys(populateHintB.dependencies).includes(fieldNameA)) {
+                  return -1; // A comes before B
+                }
+                
+                // Otherwise, maintain original order
+                return 0;
+              })
+              .map(([fieldName, fieldSchema]) => renderFormField(fieldName, fieldSchema))}
+          </div>
 
-          <DialogFooter className="mt-6">
+          <DialogFooter className="px-6 pb-6 pt-4 flex-shrink-0 border-t border-gray-800">
             <Button type="button" variant="outline" onClick={onClose}>
               Cancel
             </Button>

--- a/ui/client/src/components/agentic-ai/workspace/ValidationResultModal.tsx
+++ b/ui/client/src/components/agentic-ai/workspace/ValidationResultModal.tsx
@@ -197,8 +197,8 @@ export const ValidationResultModal: React.FC<ValidationResultModalProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-background-card border-gray-800 text-foreground max-w-2xl max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="bg-background-card border-gray-800 text-foreground max-w-2xl max-h-[80vh] flex flex-col overflow-hidden p-0 gap-0">
+        <DialogHeader className="px-6 pt-6 pb-4 flex-shrink-0 border-b border-gray-800">
           <DialogTitle className="flex items-center gap-3">
             {validationResult.is_valid ? (
               <CheckCircle2 className="h-6 w-6 text-green-500" />
@@ -209,101 +209,103 @@ export const ValidationResultModal: React.FC<ValidationResultModalProps> = ({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-6">
-          {/* Summary Section */}
-          <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-900/50 border border-gray-800">
-            <div className="flex-1">
-              <div className="flex items-center gap-2 mb-2">
-                <span className="text-sm font-medium text-gray-400">Status:</span>
-                {validationResult.is_valid ? (
-                  <Badge className="bg-green-500/20 text-green-400 border-green-500/30">
-                    Valid
-                  </Badge>
-                ) : (
-                  <Badge className="bg-red-500/20 text-red-400 border-red-500/30">
-                    Invalid
-                  </Badge>
-                )}
-              </div>
-              <div className="flex items-center gap-2 text-xs text-gray-500">
-                <span>Type: {validationResult.element_type}</span>
-                <span>•</span>
-                <span className="font-mono">{validationResult.element_rid.slice(0, 12)}...</span>
-              </div>
-            </div>
-            
-            <div className="flex items-center gap-4">
-              <div className="flex gap-3">
-                {errorCount > 0 && (
-                  <div className="flex items-center gap-1">
-                    <XCircle className="h-4 w-4 text-red-500" />
-                    <span className="text-sm text-red-400">{errorCount}</span>
-                  </div>
-                )}
-                {warningCount > 0 && (
-                  <div className="flex items-center gap-1">
-                    <AlertTriangle className="h-4 w-4 text-yellow-500" />
-                    <span className="text-sm text-yellow-400">{warningCount}</span>
-                  </div>
-                )}
-                {infoCount > 0 && (
-                  <div className="flex items-center gap-1">
-                    <Info className="h-4 w-4 text-blue-500" />
-                    <span className="text-sm text-blue-400">{infoCount}</span>
-                  </div>
-                )}
+        <div className="flex-1 overflow-y-auto px-6 py-6 min-h-0">
+          <div className="space-y-6">
+            {/* Summary Section */}
+            <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-900/50 border border-gray-800">
+              <div className="flex-1">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-sm font-medium text-gray-400">Status:</span>
+                  {validationResult.is_valid ? (
+                    <Badge className="bg-green-500/20 text-green-400 border-green-500/30">
+                      Valid
+                    </Badge>
+                  ) : (
+                    <Badge className="bg-red-500/20 text-red-400 border-red-500/30">
+                      Invalid
+                    </Badge>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 text-xs text-gray-500">
+                  <span>Type: {validationResult.element_type}</span>
+                  <span>•</span>
+                  <span className="font-mono">{validationResult.element_rid.slice(0, 12)}...</span>
+                </div>
               </div>
               
-              {showRefreshButton && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleRefreshValidation}
-                  className="h-8 px-3 hover:bg-gray-700 border-gray-700"
-                  title="Re-validate resource"
-                >
-                  <RefreshCw className="h-4 w-4 mr-2" />
-                  Refresh
-                </Button>
-              )}
-            </div>
-          </div>
-
-          {/* Messages Section */}
-          {validationResult.messages.length > 0 && (
-            <div>
-              <h3 className="text-sm font-medium text-gray-400 mb-3">Messages</h3>
-              <div className="space-y-2">
-                {validationResult.messages.map((message, idx) => (
-                  <ValidationMessageItem key={idx} message={message} />
-                ))}
+              <div className="flex items-center gap-4">
+                <div className="flex gap-3">
+                  {errorCount > 0 && (
+                    <div className="flex items-center gap-1">
+                      <XCircle className="h-4 w-4 text-red-500" />
+                      <span className="text-sm text-red-400">{errorCount}</span>
+                    </div>
+                  )}
+                  {warningCount > 0 && (
+                    <div className="flex items-center gap-1">
+                      <AlertTriangle className="h-4 w-4 text-yellow-500" />
+                      <span className="text-sm text-yellow-400">{warningCount}</span>
+                    </div>
+                  )}
+                  {infoCount > 0 && (
+                    <div className="flex items-center gap-1">
+                      <Info className="h-4 w-4 text-blue-500" />
+                      <span className="text-sm text-blue-400">{infoCount}</span>
+                    </div>
+                  )}
+                </div>
+                
+                {showRefreshButton && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleRefreshValidation}
+                    className="h-8 px-3 hover:bg-gray-700 border-gray-700"
+                    title="Re-validate resource"
+                  >
+                    <RefreshCw className="h-4 w-4 mr-2" />
+                    Refresh
+                  </Button>
+                )}
               </div>
             </div>
-          )}
 
-          {/* Dependencies Section */}
-          {hasDependencies && (
-            <div>
-              <h3 className="text-sm font-medium text-gray-400 mb-3">
-                Dependencies ({Object.keys(validationResult.dependency_results).length})
-              </h3>
-              <div className="border border-gray-800 rounded-lg p-4 bg-gray-900/30">
-                <div className="space-y-1">
-                  {Object.entries(validationResult.dependency_results).map(([rid, depResult]) => (
-                    <DependencyResultItem key={rid} result={depResult} />
+            {/* Messages Section */}
+            {validationResult.messages.length > 0 && (
+              <div>
+                <h3 className="text-sm font-medium text-gray-400 mb-3">Messages</h3>
+                <div className="space-y-2">
+                  {validationResult.messages.map((message, idx) => (
+                    <ValidationMessageItem key={idx} message={message} />
                   ))}
                 </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {/* Empty state for no messages */}
-          {validationResult.messages.length === 0 && !hasDependencies && (
-            <div className="text-center py-8 text-gray-500">
-              <CheckCircle2 className="h-12 w-12 mx-auto mb-3 opacity-50" />
-              <p>No validation messages or dependencies to display.</p>
-            </div>
-          )}
+            {/* Dependencies Section */}
+            {hasDependencies && (
+              <div>
+                <h3 className="text-sm font-medium text-gray-400 mb-3">
+                  Dependencies ({Object.keys(validationResult.dependency_results).length})
+                </h3>
+                <div className="border border-gray-800 rounded-lg p-4 bg-gray-900/30">
+                  <div className="space-y-1">
+                    {Object.entries(validationResult.dependency_results).map(([rid, depResult]) => (
+                      <DependencyResultItem key={rid} result={depResult} />
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Empty state for no messages */}
+            {validationResult.messages.length === 0 && !hasDependencies && (
+              <div className="text-center py-8 text-gray-500">
+                <CheckCircle2 className="h-12 w-12 mx-auto mb-3 opacity-50" />
+                <p>No validation messages or dependencies to display.</p>
+              </div>
+            )}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/ui/client/src/pages/AgentRepository.tsx
+++ b/ui/client/src/pages/AgentRepository.tsx
@@ -127,7 +127,7 @@ export default function UserWorkspace() {
               <div className="flex flex-col h-full">
                 {/* Header with Create Button */}
                 {selectedElementType && (
-                  <div className="flex justify-between items-center mb-6">
+                  <div className="flex justify-between items-center mb-6 sticky top-0 z-10 pb-4 pt-px -mt-px bg-[hsl(var(--background-dark))] shadow-[0_4px_12px_-2px_rgba(0,0,0,0.4)]">
                     <div>
                       <h2 className="text-2xl font-heading font-bold">
                         {selectedElementType.name} Instances

--- a/ui/client/src/workspace/ResourceDetailsModal.tsx
+++ b/ui/client/src/workspace/ResourceDetailsModal.tsx
@@ -46,8 +46,8 @@ const ResourceDetailsModal: React.FC<ResourceDetailsModalProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="bg-background-card border-gray-800 text-foreground max-w-2xl max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="bg-background-card border-gray-800 text-foreground max-w-2xl max-h-[80vh] flex flex-col overflow-hidden p-0 gap-0">
+        <DialogHeader className="px-6 pt-6 pb-4 flex-shrink-0 border-b border-gray-800">
           <DialogTitle className="flex items-center gap-2">
             <FileText className="h-5 w-5 text-primary" />
             {element?.label || 'Resource Details'}
@@ -55,71 +55,73 @@ const ResourceDetailsModal: React.FC<ResourceDetailsModalProps> = ({
         </DialogHeader>
         
         {element?.workspaceData && (
-          <div className="space-y-4">
-            {/* Basic Info */}
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="text-sm font-medium text-gray-400">Resource ID</label>
-                <p className="font-mono text-sm text-gray-300">{element.workspaceData.rid}</p>
+          <div className="flex-1 overflow-y-auto px-6 py-4 min-h-0">
+            <div className="space-y-4">
+              {/* Basic Info */}
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Resource ID</label>
+                  <p className="font-mono text-sm text-gray-300">{element.workspaceData.rid}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Type</label>
+                  <p className="text-sm text-gray-300">{element.workspaceData.type}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Version</label>
+                  <p className="text-sm text-gray-300">v{element.workspaceData.version || 1}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Category</label>
+                  <p className="text-sm text-gray-300">{element.workspaceData.category}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Created</label>
+                  <p className="text-sm text-gray-300">
+                    {element.workspaceData.created ? new Date(element.workspaceData.created).toLocaleString() : 'N/A'}
+                  </p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Last Updated</label>
+                  <p className="text-sm text-gray-300">
+                    {element.workspaceData.updated ? new Date(element.workspaceData.updated).toLocaleString() : 'N/A'}
+                  </p>
+                </div>
               </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Type</label>
-                <p className="text-sm text-gray-300">{element.workspaceData.type}</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Version</label>
-                <p className="text-sm text-gray-300">v{element.workspaceData.version || 1}</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Category</label>
-                <p className="text-sm text-gray-300">{element.workspaceData.category}</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Created</label>
-                <p className="text-sm text-gray-300">
-                  {element.workspaceData.created ? new Date(element.workspaceData.created).toLocaleString() : 'N/A'}
-                </p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Last Updated</label>
-                <p className="text-sm text-gray-300">
-                  {element.workspaceData.updated ? new Date(element.workspaceData.updated).toLocaleString() : 'N/A'}
-                </p>
-              </div>
+
+              {/* References */}
+              {element.workspaceData.nested_refs && element.workspaceData.nested_refs.length > 0 && (
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Referenced Resources</label>
+                  <div className="mt-1 space-y-1">
+                    {element.workspaceData.nested_refs.map((ref, index) => (
+                      <Badge key={index} variant="outline" className="mr-2">
+                        {getResourceName(ref)}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Configuration */}
+              {element.workspaceData.config && (
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Full Configuration</label>
+                  <div className="mt-2 bg-gray-900 p-4 rounded-md">
+                    <pre className="text-xs text-gray-300 whitespace-pre-wrap overflow-x-auto">
+                      {JSON.stringify(
+                        maskSecretFieldsInConfig(
+                          simplifyConfigForDisplay(resolveRefsInConfig(element.workspaceData.config)), 
+                          elementSchema?.config_schema
+                        ), 
+                        null, 
+                        2
+                      )}
+                    </pre>
+                  </div>
+                </div>
+              )}
             </div>
-
-            {/* References */}
-            {element.workspaceData.nested_refs && element.workspaceData.nested_refs.length > 0 && (
-              <div>
-                <label className="text-sm font-medium text-gray-400">Referenced Resources</label>
-                <div className="mt-1 space-y-1">
-                  {element.workspaceData.nested_refs.map((ref, index) => (
-                    <Badge key={index} variant="outline" className="mr-2">
-                      {getResourceName(ref)}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Configuration */}
-            {element.workspaceData.config && (
-              <div>
-                <label className="text-sm font-medium text-gray-400">Full Configuration</label>
-                <div className="mt-2 bg-gray-900 p-4 rounded-md">
-                  <pre className="text-xs text-gray-300 whitespace-pre-wrap overflow-x-auto">
-                    {JSON.stringify(
-                      maskSecretFieldsInConfig(
-                        simplifyConfigForDisplay(resolveRefsInConfig(element.workspaceData.config)), 
-                        elementSchema?.config_schema
-                      ), 
-                      null, 
-                      2
-                    )}
-                  </pre>
-                </div>
-              </div>
-            )}
           </div>
         )}
       </DialogContent>


### PR DESCRIPTION
Solely UI changes, adding sticky headers for the category titles, the X button on the configure modal, and the X buton on the yaml box.

<img width="2244" height="1157" alt="image" src="https://github.com/user-attachments/assets/31e6db72-c237-4b86-bed5-aaa1f538d4cc" />

<img width="905" height="1261" alt="image" src="https://github.com/user-attachments/assets/69e08a17-0f52-4730-82ab-9944417f3265" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Enhanced modal and panel layouts across workspace dialogs with improved scrolling behavior.
  * Fixed header and footer regions that remain visible while content scrolls.
  * Refined visual hierarchy with border separators and consistent spacing throughout dialogs.
  * Added sticky positioning to the agent repository header for better navigation context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->