### PR TITLE
feat: LDAP user/group search integration

### DIFF
--- a/shared-resources/sso-backend/app.py
+++ b/shared-resources/sso-backend/app.py
@@ -26,6 +26,20 @@ auth_manager = AuthManager(app)
 # Store auth_manager in app extensions for easy access
 app.extensions['auth_manager'] = auth_manager
 
+# Initialize LDAP client (optional - requires LDAP_URL to be set)
+if config.ldap_url:
+    from ldap.client import LDAPClient
+    import endpoints.ldap as ldap_endpoints
+
+    ldap_client = LDAPClient(
+        url=config.ldap_url,
+        base_dn=config.ldap_base_dn,
+        group_base_dn=config.ldap_group_base_dn,
+        skip_tls_verify=config.ldap_skip_tls_verify,
+    )
+    ldap_endpoints.ldap_client = ldap_client
+    print(f"LDAP client initialized: {config.ldap_url} (base DN: {config.ldap_base_dn})")
+
 register_all_endpoints(app)
 
 # Init before_request/after_request rules

--- a/shared-resources/sso-backend/config/app_config.py
+++ b/shared-resources/sso-backend/config/app_config.py
@@ -17,3 +17,9 @@ class AppConfig(SharedConfig):
     frontend_url: str = "http://localhost:5000"    # session_cookie_secure=True
     backend_env: str = "development"
 
+    # LDAP Configuration (optional - disabled if ldap_url is empty)
+    ldap_url: str = ""  # e.g. "ldaps://ldap.corp.redhat.com"
+    ldap_base_dn: str = "ou=users,dc=redhat,dc=com"
+    ldap_group_base_dn: str = ""  # derived from base_dn if empty
+    ldap_skip_tls_verify: bool = False
+

--- a/shared-resources/sso-backend/endpoints/__init__.py
+++ b/shared-resources/sso-backend/endpoints/__init__.py
@@ -1,12 +1,13 @@
 from endpoints.protected_routes import protected_bp
 from endpoints.health import health_bp
+from endpoints.ldap import ldap_bp
 
 
 def register_all_endpoints(app):
     backend_blueprints = [
         {"bp": protected_bp, "parent": 'protected', "route": ''},
         {"bp": health_bp, "parent": 'health', "route": ''},
-
+        {"bp": ldap_bp, "parent": 'ldap', "route": ''},
     ]
     
     # register all other blueprints in the app

--- a/shared-resources/sso-backend/endpoints/ldap.py
+++ b/shared-resources/sso-backend/endpoints/ldap.py
@@ -1,0 +1,64 @@
+"""LDAP user and group search endpoints."""
+from flask import Blueprint, jsonify, request
+from utils.auth_manager import require_auth
+from ldap.client import MIN_QUERY_LENGTH
+
+ldap_bp = Blueprint("ldap", __name__)
+
+# Singleton client, set by app.py at startup
+ldap_client = None
+
+
+@ldap_bp.route("/users", methods=["GET"])
+@require_auth
+def search_users():
+    """Search LDAP users by query string."""
+    query = request.args.get("q", "")
+    if len(query) < MIN_QUERY_LENGTH:
+        return jsonify({"error": f"query must be at least {MIN_QUERY_LENGTH} characters"}), 400
+
+    if ldap_client is None:
+        return jsonify({"users": []})
+
+    try:
+        users = ldap_client.search_users(query)
+        return jsonify({"users": [u.to_dict() for u in users]})
+    except Exception as e:
+        return jsonify({"error": "LDAP search unavailable"}), 503
+
+
+@ldap_bp.route("/users/<uid>", methods=["GET"])
+@require_auth
+def get_user(uid):
+    """Get a single LDAP user by UID."""
+    if not uid:
+        return jsonify({"error": "uid is required"}), 400
+
+    if ldap_client is None:
+        return jsonify({"error": "LDAP not configured"}), 404
+
+    try:
+        user = ldap_client.get_user(uid)
+        if user is None:
+            return jsonify({"error": "User not found"}), 404
+        return jsonify(user.to_dict())
+    except Exception as e:
+        return jsonify({"error": "Failed to look up user"}), 500
+
+
+@ldap_bp.route("/groups", methods=["GET"])
+@require_auth
+def search_groups():
+    """Search LDAP groups by query string."""
+    query = request.args.get("q", "")
+    if len(query) < MIN_QUERY_LENGTH:
+        return jsonify({"error": f"query must be at least {MIN_QUERY_LENGTH} characters"}), 400
+
+    if ldap_client is None:
+        return jsonify({"groups": []})
+
+    try:
+        groups = ldap_client.search_groups(query)
+        return jsonify({"groups": [g.to_dict() for g in groups]})
+    except Exception as e:
+        return jsonify({"error": "LDAP search unavailable"}), 503

--- a/shared-resources/sso-backend/ldap/client.py
+++ b/shared-resources/sso-backend/ldap/client.py
@@ -1,0 +1,214 @@
+"""
+LDAP client for user and group lookups against Red Hat LDAP.
+Ported from ambient-code/platform (Go) to Python.
+"""
+import threading
+from dataclasses import dataclass, field
+
+from cachetools import TTLCache
+from ldap3 import Server, Connection, Tls, SUBTREE
+from ldap3.utils.conv import escape_filter_chars
+import ssl
+
+# Constants
+DEFAULT_CONN_TIMEOUT = 5
+DEFAULT_QUERY_TIMEOUT = 3
+DEFAULT_MAX_RESULTS = 10
+DEFAULT_CACHE_TTL = 300  # 5 minutes
+MIN_QUERY_LENGTH = 2
+MAX_QUERY_LENGTH = 50
+
+USER_ATTRIBUTES = ["uid", "cn", "mail", "title", "rhatSocialURL", "memberOf"]
+
+
+@dataclass
+class LDAPUser:
+    uid: str = ""
+    full_name: str = ""
+    email: str = ""
+    title: str = ""
+    github_username: str = ""
+    groups: list = field(default_factory=list)
+
+    def to_dict(self):
+        return {
+            "uid": self.uid,
+            "fullName": self.full_name,
+            "email": self.email,
+            "title": self.title,
+            "githubUsername": self.github_username,
+            "groups": self.groups,
+        }
+
+
+@dataclass
+class LDAPGroup:
+    name: str = ""
+    description: str = ""
+
+    def to_dict(self):
+        return {"name": self.name, "description": self.description}
+
+
+def sanitize_query(q: str) -> str:
+    q = q.strip()
+    q = q.replace("\n", "").replace("\r", "")
+    if len(q) > MAX_QUERY_LENGTH:
+        q = q[:MAX_QUERY_LENGTH]
+    return q
+
+
+def user_search_filter(query: str) -> str:
+    words = query.split()
+    if not words:
+        return "(uid=*)"
+    if len(words) == 1:
+        escaped = escape_filter_chars(words[0])
+        return f"(|(uid=*{escaped}*)(givenName=*{escaped}*)(sn=*{escaped}*))"
+    parts = []
+    for w in words:
+        escaped = escape_filter_chars(w)
+        parts.append(f"(|(uid=*{escaped}*)(givenName=*{escaped}*)(sn=*{escaped}*))")
+    return "(&" + "".join(parts) + ")"
+
+
+def group_search_filter(query: str) -> str:
+    escaped = escape_filter_chars(query)
+    return f"(cn={escaped}*)"
+
+
+def parse_github_username(social_url: str) -> str:
+    prefix = "Github->https://github.com/"
+    if not social_url.startswith(prefix):
+        return ""
+    username = social_url[len(prefix):]
+    username = username.rstrip("/")
+    if "/" in username:
+        username = username[: username.index("/")]
+    return username
+
+
+def extract_cn_from_dn(dn: str) -> str:
+    if not dn:
+        return ""
+    for part in dn.split(","):
+        part = part.strip()
+        if part.lower().startswith("cn="):
+            return part[3:]
+    return ""
+
+
+def _entry_to_user(entry) -> LDAPUser:
+    user = LDAPUser(
+        uid=(entry.uid.value or "") if hasattr(entry, "uid") else "",
+        full_name=(entry.cn.value or "") if hasattr(entry, "cn") else "",
+        email=(entry.mail.value or "") if hasattr(entry, "mail") else "",
+        title=(entry.title.value or "") if hasattr(entry, "title") else "",
+    )
+    if hasattr(entry, "rhatSocialURL"):
+        urls = entry.rhatSocialURL.values if hasattr(entry.rhatSocialURL, "values") else []
+        for url in urls:
+            gh = parse_github_username(str(url))
+            if gh:
+                user.github_username = gh
+                break
+    if hasattr(entry, "memberOf"):
+        members = entry.memberOf.values if hasattr(entry.memberOf, "values") else []
+        for dn_val in members:
+            cn = extract_cn_from_dn(str(dn_val))
+            if cn:
+                user.groups.append(cn)
+    return user
+
+
+class LDAPClient:
+    def __init__(self, url: str, base_dn: str, group_base_dn: str = "", skip_tls_verify: bool = False):
+        self.url = url
+        self.base_dn = base_dn
+        self.skip_tls_verify = skip_tls_verify
+        if group_base_dn:
+            self.group_base_dn = group_base_dn
+        else:
+            parts = base_dn.split(",", 1)
+            if len(parts) == 2:
+                self.group_base_dn = f"ou=managedGroups,{parts[1]}"
+            else:
+                self.group_base_dn = "ou=managedGroups,dc=redhat,dc=com"
+        self._cache = TTLCache(maxsize=100, ttl=DEFAULT_CACHE_TTL)
+        self._cache_lock = threading.Lock()
+
+    def _connect(self) -> Connection:
+        tls_config = None
+        if self.url.startswith("ldaps://"):
+            tls_config = Tls(validate=ssl.CERT_NONE if self.skip_tls_verify else ssl.CERT_REQUIRED)
+        server = Server(self.url, use_ssl=self.url.startswith("ldaps://"), tls=tls_config, connect_timeout=DEFAULT_CONN_TIMEOUT)
+        conn = Connection(server, auto_bind=True, read_only=True)
+        return conn
+
+    def _cache_get(self, key: str):
+        with self._cache_lock:
+            return self._cache.get(key)
+
+    def _cache_set(self, key: str, value):
+        with self._cache_lock:
+            self._cache[key] = value
+
+    def search_users(self, query: str) -> list[LDAPUser]:
+        query = sanitize_query(query)
+        if len(query) < MIN_QUERY_LENGTH:
+            return []
+        cache_key = f"users:{query}"
+        cached = self._cache_get(cache_key)
+        if cached is not None:
+            return cached
+        conn = self._connect()
+        try:
+            conn.search(search_base=self.base_dn, search_filter=user_search_filter(query), search_scope=SUBTREE, attributes=USER_ATTRIBUTES, size_limit=DEFAULT_MAX_RESULTS, time_limit=DEFAULT_QUERY_TIMEOUT)
+            users = [_entry_to_user(entry) for entry in conn.entries]
+            self._cache_set(cache_key, users)
+            return users
+        finally:
+            conn.unbind()
+
+    def search_groups(self, query: str) -> list[LDAPGroup]:
+        query = sanitize_query(query)
+        if len(query) < MIN_QUERY_LENGTH:
+            return []
+        cache_key = f"groups:{query}"
+        cached = self._cache_get(cache_key)
+        if cached is not None:
+            return cached
+        conn = self._connect()
+        try:
+            conn.search(search_base=self.group_base_dn, search_filter=group_search_filter(query), search_scope=SUBTREE, attributes=["cn", "description"], size_limit=DEFAULT_MAX_RESULTS, time_limit=DEFAULT_QUERY_TIMEOUT)
+            groups = [
+                LDAPGroup(
+                    name=(entry.cn.value or "") if hasattr(entry, "cn") else "",
+                    description=(entry.description.value or "") if hasattr(entry, "description") else "",
+                )
+                for entry in conn.entries
+            ]
+            self._cache_set(cache_key, groups)
+            return groups
+        finally:
+            conn.unbind()
+
+    def get_user(self, uid: str) -> LDAPUser | None:
+        uid = sanitize_query(uid)
+        if not uid:
+            return None
+        cache_key = f"user:{uid}"
+        cached = self._cache_get(cache_key)
+        if cached is not None:
+            return cached
+        conn = self._connect()
+        try:
+            escaped = escape_filter_chars(uid)
+            conn.search(search_base=self.base_dn, search_filter=f"(uid={escaped})", search_scope=SUBTREE, attributes=USER_ATTRIBUTES, size_limit=1, time_limit=DEFAULT_QUERY_TIMEOUT)
+            if not conn.entries:
+                return None
+            user = _entry_to_user(conn.entries[0])
+            self._cache_set(cache_key, user)
+            return user
+        finally:
+            conn.unbind()

--- a/shared-resources/sso-backend/ldap/test_client.py
+++ b/shared-resources/sso-backend/ldap/test_client.py
@@ -1,0 +1,214 @@
+"""Unit tests for LDAP client helpers - no LDAP server needed."""
+import pytest
+from ldap.client import (
+    sanitize_query,
+    user_search_filter,
+    group_search_filter,
+    parse_github_username,
+    extract_cn_from_dn,
+    _entry_to_user,
+    MIN_QUERY_LENGTH,
+    LDAPClient,
+    LDAPUser,
+    LDAPGroup,
+)
+
+
+class TestSanitizeQuery:
+    def test_normal_query(self):
+        assert sanitize_query("jdoe") == "jdoe"
+
+    def test_strips_whitespace(self):
+        assert sanitize_query("  jdoe  ") == "jdoe"
+
+    def test_strips_newlines(self):
+        assert sanitize_query("foo\nbar") == "foobar"
+
+    def test_strips_carriage_return(self):
+        assert sanitize_query("foo\rbar") == "foobar"
+
+    def test_strips_crlf(self):
+        assert sanitize_query("foo\r\nbar") == "foobar"
+
+    def test_truncates_long_query(self):
+        long = "a" * 60
+        assert len(sanitize_query(long)) == 50
+
+    def test_empty_string(self):
+        assert sanitize_query("") == ""
+
+
+class TestUserSearchFilter:
+    def test_single_word(self):
+        result = user_search_filter("jdoe")
+        assert result == "(|(uid=*jdoe*)(givenName=*jdoe*)(sn=*jdoe*))"
+
+    def test_multi_word(self):
+        result = user_search_filter("Jane Do")
+        assert result == "(&(|(uid=*Jane*)(givenName=*Jane*)(sn=*Jane*))(|(uid=*Do*)(givenName=*Do*)(sn=*Do*)))"
+
+    def test_special_chars_escaped(self):
+        result = user_search_filter("user(test)")
+        assert "\\28" in result
+        assert "\\29" in result
+
+    def test_asterisk_escaped(self):
+        result = user_search_filter("user*")
+        assert "\\2a" in result
+
+    def test_empty_returns_wildcard(self):
+        assert user_search_filter("") == "(uid=*)"
+
+
+class TestGroupSearchFilter:
+    def test_simple_query(self):
+        assert group_search_filter("aipcc") == "(cn=aipcc*)"
+
+    def test_special_chars_escaped(self):
+        result = group_search_filter("group(test)")
+        assert "\\28" in result
+
+
+class TestParseGithubUsername:
+    def test_valid_url(self):
+        assert parse_github_username("Github->https://github.com/jdoe") == "jdoe"
+
+    def test_trailing_slash(self):
+        assert parse_github_username("Github->https://github.com/jdoe/") == "jdoe"
+
+    def test_extra_path(self):
+        assert parse_github_username("Github->https://github.com/jdoe/repos") == "jdoe"
+
+    def test_non_github(self):
+        assert parse_github_username("Twitter->https://twitter.com/jdoe") == ""
+
+    def test_empty(self):
+        assert parse_github_username("") == ""
+
+    def test_partial_prefix(self):
+        assert parse_github_username("Github->https://github.com/") == ""
+
+    def test_wrong_case(self):
+        assert parse_github_username("github->https://github.com/jdoe") == ""
+
+
+class TestExtractCnFromDn:
+    def test_standard_dn(self):
+        assert extract_cn_from_dn("cn=aipcc-eng-all,ou=managedGroups,dc=redhat,dc=com") == "aipcc-eng-all"
+
+    def test_spaces(self):
+        assert extract_cn_from_dn("cn=My Group, ou=groups, dc=example, dc=com") == "My Group"
+
+    def test_no_cn(self):
+        assert extract_cn_from_dn("ou=managedGroups,dc=redhat,dc=com") == ""
+
+    def test_empty(self):
+        assert extract_cn_from_dn("") == ""
+
+    def test_uppercase_cn(self):
+        assert extract_cn_from_dn("CN=TestGroup,ou=groups,dc=example,dc=com") == "TestGroup"
+
+
+class TestLDAPClientInit:
+    def test_default_group_base_dn_derived(self):
+        client = LDAPClient("ldaps://ldap.example.com", "ou=users,dc=redhat,dc=com")
+        assert client.group_base_dn == "ou=managedGroups,dc=redhat,dc=com"
+
+    def test_explicit_group_base_dn(self):
+        client = LDAPClient("ldaps://ldap.example.com", "ou=users,dc=example,dc=com", "ou=groups,dc=example,dc=com")
+        assert client.group_base_dn == "ou=groups,dc=example,dc=com"
+
+    def test_cache_set_and_get(self):
+        client = LDAPClient("ldaps://ldap.example.com", "ou=users,dc=redhat,dc=com")
+        client._cache_set("test-key", "test-value")
+        assert client._cache_get("test-key") == "test-value"
+
+    def test_cache_miss(self):
+        client = LDAPClient("ldaps://ldap.example.com", "ou=users,dc=redhat,dc=com")
+        assert client._cache_get("nonexistent") is None
+
+    def test_search_users_short_query_returns_empty(self):
+        client = LDAPClient("ldaps://ldap.example.com", "ou=users,dc=redhat,dc=com")
+        assert client.search_users("m") == []
+
+    def test_search_groups_short_query_returns_empty(self):
+        client = LDAPClient("ldaps://ldap.example.com", "ou=users,dc=redhat,dc=com")
+        assert client.search_groups("a") == []
+
+    def test_get_user_empty_uid_returns_none(self):
+        client = LDAPClient("ldaps://ldap.example.com", "ou=users,dc=redhat,dc=com")
+        assert client.get_user("") is None
+
+
+class TestLDAPUserToDict:
+    def test_to_dict_camel_case_keys(self):
+        user = LDAPUser(uid="iezra", full_name="Itzik Ezra", email="iezra@redhat.com",
+                        title="QE Engineer", github_username="ItzikEzra-rh", groups=["hw-accel-qe"])
+        d = user.to_dict()
+        assert d == {
+            "uid": "iezra",
+            "fullName": "Itzik Ezra",
+            "email": "iezra@redhat.com",
+            "title": "QE Engineer",
+            "githubUsername": "ItzikEzra-rh",
+            "groups": ["hw-accel-qe"],
+        }
+
+    def test_to_dict_defaults(self):
+        user = LDAPUser()
+        d = user.to_dict()
+        assert d["uid"] == ""
+        assert d["groups"] == []
+
+
+class TestLDAPGroupToDict:
+    def test_to_dict(self):
+        group = LDAPGroup(name="aipcc-eng-all", description="All AIPCC engineers")
+        assert group.to_dict() == {"name": "aipcc-eng-all", "description": "All AIPCC engineers"}
+
+
+class TestEntryToUser:
+    """Test _entry_to_user with mock ldap3-like entry objects."""
+
+    def _make_entry(self, attrs):
+        """Create a mock entry with attribute-like access."""
+        class AttrVal:
+            def __init__(self, val):
+                self.value = val
+                self.values = val if isinstance(val, list) else [val]
+        class Entry:
+            pass
+        entry = Entry()
+        for k, v in attrs.items():
+            setattr(entry, k, AttrVal(v))
+        return entry
+
+    def test_full_entry(self):
+        entry = self._make_entry({
+            "uid": "jdoe",
+            "cn": "Jane Doe",
+            "mail": "jdoe@redhat.com",
+            "title": "Engineer",
+            "rhatSocialURL": ["Github->https://github.com/janedoe"],
+            "memberOf": ["cn=team-a,ou=managedGroups,dc=redhat,dc=com"],
+        })
+        user = _entry_to_user(entry)
+        assert user.uid == "jdoe"
+        assert user.full_name == "Jane Doe"
+        assert user.email == "jdoe@redhat.com"
+        assert user.github_username == "janedoe"
+        assert user.groups == ["team-a"]
+
+    def test_missing_optional_attrs(self):
+        entry = self._make_entry({"uid": "jdoe", "cn": "Jane Doe"})
+        user = _entry_to_user(entry)
+        assert user.uid == "jdoe"
+        assert user.email == ""
+        assert user.github_username == ""
+        assert user.groups == []
+
+    def test_completely_empty_entry(self):
+        entry = self._make_entry({})
+        user = _entry_to_user(entry)
+        assert user.uid == ""
+        assert user.full_name == ""

--- a/shared-resources/sso-backend/requirements.txt
+++ b/shared-resources/sso-backend/requirements.txt
@@ -6,3 +6,5 @@ PyJWT
 python-dotenv
 pydantic
 pydantic-settings
+ldap3>=2.9.1
+cachetools>=5.3.0


### PR DESCRIPTION
## Summary
- Add LDAP client library (`shared-resources/sso-backend/ldap/`) ported from ambient-code/platform (Go → Python)
- Add 3 Flask endpoints for user/group search (`/api/ldap/`)
- Optional feature: disabled by default, enabled by setting `LDAP_URL` env var
- 39 unit tests covering all helpers, dataclasses, and client behavior

## Architecture
- **Client** (`ldap/client.py`): Uses `ldap3` with TLS, in-memory TTL cache (5min, thread-safe), query sanitization, LDAP injection prevention via `escape_filter_chars`
- **Endpoints** (`endpoints/ldap.py`): Flask Blueprint with `require_auth` decorator, graceful degradation when LDAP not configured
- **Config** (`config/app_config.py`): 4 new fields (`ldap_url`, `ldap_base_dn`, `ldap_group_base_dn`, `ldap_skip_tls_verify`)
- **Reference**: Ported from [ambient-code/platform](https://github.com/ambient-code/platform/tree/main/components/backend/ldap) service-account integration

## Endpoints
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/api/ldap/users?q=<query>` | Required | Search users (uid, givenName, sn substring) |
| GET | `/api/ldap/users/<uid>` | Required | Get user by exact UID |
| GET | `/api/ldap/groups?q=<query>` | Required | Search groups (cn prefix) |

## Dependencies Added
- `ldap3>=2.9.1` (pure Python LDAP client)
- `cachetools>=5.3.0` (TTL cache)

## Config (env vars)
| Variable | Required | Default |
|----------|----------|---------|
| `LDAP_URL` | Yes (to enable) | empty (disabled) |
| `LDAP_BASE_DN` | No | `ou=users,dc=redhat,dc=com` |
| `LDAP_GROUP_BASE_DN` | No | derived from base DN |
| `LDAP_SKIP_TLS_VERIFY` | No | `false` |

## Test plan
- [x] 39 unit tests pass (helpers, filters, dataclasses, cache, client init, entry conversion)
- [ ] Integration test against RH LDAP (requires VPN + service-account credentials)
- [ ] Helm values update for deployment