### PR TITLE
GENIE-1401/story/chat-session-export

### DIFF
--- a/ui/client/src/components/agentic-ai/chat/ChatInterface.tsx
+++ b/ui/client/src/components/agentic-ai/chat/ChatInterface.tsx
@@ -748,14 +748,14 @@ export default function ChatInterface({
   };
 
   const handleExportMarkdown = useCallback(() => {
-    const md = exportSessionAsMarkdown(messages);
-    downloadFile(md, buildExportFilename(undefined, "md"), "text/markdown");
-  }, [messages]);
+    const md = exportSessionAsMarkdown(messages, runId);
+    downloadFile(md, buildExportFilename(runId, "md"), "text/markdown");
+  }, [messages, runId]);
 
   const handleExportJSON = useCallback(() => {
-    const json = exportSessionAsJSON(messages);
-    downloadFile(json, buildExportFilename(undefined, "json"), "application/json");
-  }, [messages]);
+    const json = exportSessionAsJSON(messages, runId);
+    downloadFile(json, buildExportFilename(runId, "json"), "application/json");
+  }, [messages, runId]);
 
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });

--- a/ui/client/src/components/agentic-ai/chat/ChatInterface.tsx
+++ b/ui/client/src/components/agentic-ai/chat/ChatInterface.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { motion, AnimatePresence } from "framer-motion";
-import { Send, Trash2, Loader2, Sparkles, Info, Copy, RotateCcw, ThumbsUp, ThumbsDown, Check, Columns3, MessageSquare, Network, Maximize2, Minimize2 } from "lucide-react";
+import { Send, Trash2, Loader2, Sparkles, Info, Copy, RotateCcw, ThumbsUp, ThumbsDown, Check, Columns3, MessageSquare, Network, Maximize2, Minimize2, Download, FileText, FileJson } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import axios from "../../../http/axiosAgentConfig";
@@ -22,6 +22,18 @@ import { useToast } from "@/hooks/use-toast";
 import { UmamiTrack } from '@/components/ui/umamitrack';
 import { UmamiEvents } from '@/config/umamiEvents';
 import WorkflowStatusBanner, { WorkflowBannerMessages } from '@/components/shared/WorkflowStatusBanner';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  exportSessionAsMarkdown,
+  exportSessionAsJSON,
+  downloadFile,
+  buildExportFilename,
+} from "./exportSession";
 
 
 // Backend message format
@@ -1000,6 +1012,39 @@ export default function ChatInterface({
       <CardHeader className="py-4 px-6 flex flex-row justify-between items-center flex-shrink-0">
         <CardTitle className="text-lg font-heading">AI Assistant</CardTitle>
         <div className="flex space-x-1 items-center">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-gray-400 hover:text-gray-100"
+                title="Export chat"
+                disabled={messages.length === 0}
+              >
+                <Download className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="bg-background-card border-gray-700">
+              <DropdownMenuItem
+                onClick={() => {
+                  const md = exportSessionAsMarkdown(messages);
+                  downloadFile(md, buildExportFilename(undefined, "md"), "text/markdown");
+                }}
+              >
+                <FileText className="h-4 w-4 mr-2" />
+                Export as Markdown (.md)
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => {
+                  const json = exportSessionAsJSON(messages);
+                  downloadFile(json, buildExportFilename(undefined, "json"), "application/json");
+                }}
+              >
+                <FileJson className="h-4 w-4 mr-2" />
+                Export as JSON (.json)
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
           {!isChatOnlyMode && (
             <>
               <Button

--- a/ui/client/src/components/agentic-ai/chat/ChatInterface.tsx
+++ b/ui/client/src/components/agentic-ai/chat/ChatInterface.tsx
@@ -9,7 +9,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { motion, AnimatePresence } from "framer-motion";
-import { Send, Trash2, Loader2, Sparkles, Info, Copy, RotateCcw, ThumbsUp, ThumbsDown, Check, Columns3, MessageSquare, Network, Maximize2, Minimize2, Download, FileText, FileJson } from "lucide-react";
+import {
+  Send, Trash2, Loader2, Sparkles, Info, Copy, RotateCcw,
+  ThumbsUp, ThumbsDown, Check, Columns3, MessageSquare, Network,
+  Maximize2, Minimize2, Download, FileText, FileJson,
+} from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import axios from "../../../http/axiosAgentConfig";
@@ -34,7 +38,6 @@ import {
   downloadFile,
   buildExportFilename,
 } from "./exportSession";
-
 
 // Backend message format
 interface BackendMessage {
@@ -744,6 +747,16 @@ export default function ChatInterface({
     stopStreamingLogs();
   };
 
+  const handleExportMarkdown = useCallback(() => {
+    const md = exportSessionAsMarkdown(messages);
+    downloadFile(md, buildExportFilename(undefined, "md"), "text/markdown");
+  }, [messages]);
+
+  const handleExportJSON = useCallback(() => {
+    const json = exportSessionAsJSON(messages);
+    downloadFile(json, buildExportFilename(undefined, "json"), "application/json");
+  }, [messages]);
+
   const formatTime = (date: Date) => {
     return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
   };
@@ -1024,22 +1037,12 @@ export default function ChatInterface({
                 <Download className="h-4 w-4" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="bg-background-card border-gray-700">
-              <DropdownMenuItem
-                onClick={() => {
-                  const md = exportSessionAsMarkdown(messages);
-                  downloadFile(md, buildExportFilename(undefined, "md"), "text/markdown");
-                }}
-              >
+            <DropdownMenuContent align="end" className="bg-popover border-gray-700">
+              <DropdownMenuItem onClick={handleExportMarkdown}>
                 <FileText className="h-4 w-4 mr-2" />
                 Export as Markdown (.md)
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => {
-                  const json = exportSessionAsJSON(messages);
-                  downloadFile(json, buildExportFilename(undefined, "json"), "application/json");
-                }}
-              >
+              <DropdownMenuItem onClick={handleExportJSON}>
                 <FileJson className="h-4 w-4 mr-2" />
                 Export as JSON (.json)
               </DropdownMenuItem>

--- a/ui/client/src/components/agentic-ai/chat/exportSession.ts
+++ b/ui/client/src/components/agentic-ai/chat/exportSession.ts
@@ -7,7 +7,7 @@ import type {
 } from "./types";
 
 // ---------------------------------------------------------------------------
-// Download helper
+// Blob download
 // ---------------------------------------------------------------------------
 
 export function downloadFile(
@@ -17,27 +17,52 @@ export function downloadFile(
 ): void {
   const blob = new Blob([content], { type: mimeType });
   const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = filename;
-  link.style.display = "none";
-  document.body.appendChild(link);
-  link.click();
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.style.display = "none";
+  document.body.appendChild(anchor);
+  anchor.click();
   setTimeout(() => {
-    document.body.removeChild(link);
+    document.body.removeChild(anchor);
     URL.revokeObjectURL(url);
   }, 100);
 }
 
 // ---------------------------------------------------------------------------
-// Markdown export
+// Filename helper
 // ---------------------------------------------------------------------------
+
+export function buildExportFilename(
+  sessionTitle: string | undefined,
+  extension: "md" | "json",
+): string {
+  const datePart = new Date().toISOString().slice(0, 10);
+  const slug = sessionTitle
+    ? sessionTitle
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "")
+        .slice(0, 40)
+    : "chat";
+  return `${slug}-export-${datePart}.${extension}`;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown export — private helpers
+// ---------------------------------------------------------------------------
+
+function escapeTableCell(text: string): string {
+  return text.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
 
 function formatToolEntry(tool: ToolEntry): string {
   const parts: string[] = [`**${tool.name}**`];
 
   if (tool.args && Object.keys(tool.args).length > 0) {
-    parts.push(`Arguments:\n\`\`\`json\n${JSON.stringify(tool.args, null, 2)}\n\`\`\``);
+    parts.push(
+      `Arguments:\n\`\`\`json\n${JSON.stringify(tool.args, null, 2)}\n\`\`\``,
+    );
   }
 
   if (tool.output) {
@@ -52,6 +77,7 @@ function formatStreamLogs(logs: StreamLogEntry[]): string {
 
   for (const log of logs) {
     lines.push(`**${log.nodeName}** — ${log.status}`);
+
     if (log.message) {
       lines.push(`> ${log.message.replace(/\n/g, "\n> ")}\n`);
     }
@@ -73,33 +99,33 @@ function formatWorkPlans(snapshots: WorkPlanSnapshot[]): string {
 
   for (const snapshot of snapshots) {
     const plan = snapshot.workplan;
+    if (!plan) continue;
+
     const planTitle = snapshot.display_name || plan.summary || "Work Plan";
     lines.push(`### Work Plan: ${planTitle}\n`);
 
-    const items = Object.values(plan.items);
-    if (items.length > 0) {
-      lines.push("| Item | Status | Assigned To | Description |");
-      lines.push("|------|--------|-------------|-------------|");
-      for (const item of items) {
-        const assignee = item.assigned_uid || "—";
-        const desc = item.description
-          ? item.description.replace(/\|/g, "\\|").replace(/\n/g, " ")
-          : "—";
-        lines.push(
-          `| ${item.title.replace(/\|/g, "\\|")} | ${item.status} | ${assignee} | ${desc} |`,
-        );
-      }
-      lines.push("");
+    const items: WorkItem[] = plan.items ? Object.values(plan.items) : [];
+    if (items.length === 0) continue;
 
-      const completedWithResults = items.filter(
-        (i: WorkItem) => i.result?.final_summary,
-      );
-      if (completedWithResults.length > 0) {
-        lines.push("#### Work Item Results\n");
-        for (const item of completedWithResults) {
-          lines.push(`**${item.title}**`);
-          lines.push(`> ${item.result!.final_summary!.replace(/\n/g, "\n> ")}\n`);
-        }
+    lines.push("| Item | Status | Assigned To | Description |");
+    lines.push("|------|--------|-------------|-------------|");
+
+    for (const item of items) {
+      const title = escapeTableCell(item.title);
+      const assignee = item.assigned_uid || "—";
+      const desc = item.description ? escapeTableCell(item.description) : "—";
+      lines.push(`| ${title} | ${item.status} | ${assignee} | ${desc} |`);
+    }
+    lines.push("");
+
+    const withResults = items.filter((i) => i.result?.final_summary);
+    if (withResults.length > 0) {
+      lines.push("#### Work Item Results\n");
+      for (const item of withResults) {
+        lines.push(`**${item.title}**`);
+        lines.push(
+          `> ${item.result!.final_summary!.replace(/\n/g, "\n> ")}\n`,
+        );
       }
     }
   }
@@ -107,15 +133,18 @@ function formatWorkPlans(snapshots: WorkPlanSnapshot[]): string {
   return lines.join("\n");
 }
 
+// ---------------------------------------------------------------------------
+// Markdown export — public
+// ---------------------------------------------------------------------------
+
 export function exportSessionAsMarkdown(
   messages: Message[],
   sessionTitle?: string,
 ): string {
   const lines: string[] = [];
-  const timestamp = new Date().toLocaleString();
 
   lines.push("# Chat Export");
-  lines.push(`**Exported:** ${timestamp}`);
+  lines.push(`**Exported:** ${new Date().toLocaleString()}`);
   if (sessionTitle) {
     lines.push(`**Session:** ${sessionTitle}`);
   }
@@ -136,10 +165,10 @@ export function exportSessionAsMarkdown(
         lines.push(formatWorkPlans(msg.workPlans));
       }
 
-      const responseText = msg.finalAnswer || msg.content;
-      if (responseText) {
+      const response = msg.finalAnswer || msg.content;
+      if (response) {
         lines.push("### Response\n");
-        lines.push(responseText);
+        lines.push(response);
       }
     }
 
@@ -153,9 +182,24 @@ export function exportSessionAsMarkdown(
 // JSON export
 // ---------------------------------------------------------------------------
 
-function stripUiFields(messages: Message[]): any[] {
+interface CleanedMessage {
+  id: string;
+  sender: "user" | "ai";
+  content: string;
+  finalAnswer?: string;
+  streamLogs?: Omit<StreamLogEntry, "isExpanded">[];
+  workPlans?: Omit<WorkPlanSnapshot, "isExpanded">[];
+}
+
+interface ExportPayload {
+  exportedAt: string;
+  sessionTitle: string | null;
+  messages: CleanedMessage[];
+}
+
+function stripUiFields(messages: Message[]): CleanedMessage[] {
   return messages.map((msg) => {
-    const cleaned: any = {
+    const cleaned: CleanedMessage = {
       id: msg.id,
       sender: msg.sender,
       content: msg.content,
@@ -185,30 +229,11 @@ export function exportSessionAsJSON(
   messages: Message[],
   sessionTitle?: string,
 ): string {
-  const payload = {
+  const payload: ExportPayload = {
     exportedAt: new Date().toISOString(),
-    sessionTitle: sessionTitle || null,
+    sessionTitle: sessionTitle ?? null,
     messages: stripUiFields(messages),
   };
 
   return JSON.stringify(payload, null, 2);
-}
-
-// ---------------------------------------------------------------------------
-// Filename helper
-// ---------------------------------------------------------------------------
-
-export function buildExportFilename(
-  sessionTitle: string | undefined,
-  extension: "md" | "json",
-): string {
-  const datePart = new Date().toISOString().slice(0, 10);
-  const slug = sessionTitle
-    ? sessionTitle
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/^-|-$/g, "")
-        .slice(0, 40)
-    : "chat";
-  return `${slug}-export-${datePart}.${extension}`;
 }

--- a/ui/client/src/components/agentic-ai/chat/exportSession.ts
+++ b/ui/client/src/components/agentic-ai/chat/exportSession.ts
@@ -1,0 +1,214 @@
+import type {
+  Message,
+  StreamLogEntry,
+  ToolEntry,
+  WorkPlanSnapshot,
+  WorkItem,
+} from "./types";
+
+// ---------------------------------------------------------------------------
+// Download helper
+// ---------------------------------------------------------------------------
+
+export function downloadFile(
+  content: string,
+  filename: string,
+  mimeType: string,
+): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+  setTimeout(() => {
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, 100);
+}
+
+// ---------------------------------------------------------------------------
+// Markdown export
+// ---------------------------------------------------------------------------
+
+function formatToolEntry(tool: ToolEntry): string {
+  const parts: string[] = [`**${tool.name}**`];
+
+  if (tool.args && Object.keys(tool.args).length > 0) {
+    parts.push(`Arguments:\n\`\`\`json\n${JSON.stringify(tool.args, null, 2)}\n\`\`\``);
+  }
+
+  if (tool.output) {
+    parts.push(`Output:\n\`\`\`\n${tool.output}\n\`\`\``);
+  }
+
+  return parts.join("\n");
+}
+
+function formatStreamLogs(logs: StreamLogEntry[]): string {
+  const lines: string[] = ["### Agent Activity\n"];
+
+  for (const log of logs) {
+    lines.push(`**${log.nodeName}** — ${log.status}`);
+    if (log.message) {
+      lines.push(`> ${log.message.replace(/\n/g, "\n> ")}\n`);
+    }
+
+    if (log.tools && log.tools.length > 0) {
+      lines.push("#### Tool Calls\n");
+      for (const tool of log.tools) {
+        lines.push(formatToolEntry(tool));
+        lines.push("");
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatWorkPlans(snapshots: WorkPlanSnapshot[]): string {
+  const lines: string[] = [];
+
+  for (const snapshot of snapshots) {
+    const plan = snapshot.workplan;
+    const planTitle = snapshot.display_name || plan.summary || "Work Plan";
+    lines.push(`### Work Plan: ${planTitle}\n`);
+
+    const items = Object.values(plan.items);
+    if (items.length > 0) {
+      lines.push("| Item | Status | Assigned To | Description |");
+      lines.push("|------|--------|-------------|-------------|");
+      for (const item of items) {
+        const assignee = item.assigned_uid || "—";
+        const desc = item.description
+          ? item.description.replace(/\|/g, "\\|").replace(/\n/g, " ")
+          : "—";
+        lines.push(
+          `| ${item.title.replace(/\|/g, "\\|")} | ${item.status} | ${assignee} | ${desc} |`,
+        );
+      }
+      lines.push("");
+
+      const completedWithResults = items.filter(
+        (i: WorkItem) => i.result?.final_summary,
+      );
+      if (completedWithResults.length > 0) {
+        lines.push("#### Work Item Results\n");
+        for (const item of completedWithResults) {
+          lines.push(`**${item.title}**`);
+          lines.push(`> ${item.result!.final_summary!.replace(/\n/g, "\n> ")}\n`);
+        }
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function exportSessionAsMarkdown(
+  messages: Message[],
+  sessionTitle?: string,
+): string {
+  const lines: string[] = [];
+  const timestamp = new Date().toLocaleString();
+
+  lines.push("# Chat Export");
+  lines.push(`**Exported:** ${timestamp}`);
+  if (sessionTitle) {
+    lines.push(`**Session:** ${sessionTitle}`);
+  }
+  lines.push("\n---\n");
+
+  for (const msg of messages) {
+    if (msg.sender === "user") {
+      lines.push("## User\n");
+      lines.push(msg.content);
+    } else {
+      lines.push("## Assistant\n");
+
+      if (msg.streamLogs && msg.streamLogs.length > 0) {
+        lines.push(formatStreamLogs(msg.streamLogs));
+      }
+
+      if (msg.workPlans && msg.workPlans.length > 0) {
+        lines.push(formatWorkPlans(msg.workPlans));
+      }
+
+      const responseText = msg.finalAnswer || msg.content;
+      if (responseText) {
+        lines.push("### Response\n");
+        lines.push(responseText);
+      }
+    }
+
+    lines.push("\n---\n");
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// JSON export
+// ---------------------------------------------------------------------------
+
+function stripUiFields(messages: Message[]): any[] {
+  return messages.map((msg) => {
+    const cleaned: any = {
+      id: msg.id,
+      sender: msg.sender,
+      content: msg.content,
+    };
+
+    if (msg.finalAnswer) {
+      cleaned.finalAnswer = msg.finalAnswer;
+    }
+
+    if (msg.streamLogs && msg.streamLogs.length > 0) {
+      cleaned.streamLogs = msg.streamLogs.map(
+        ({ isExpanded: _, ...rest }) => rest,
+      );
+    }
+
+    if (msg.workPlans && msg.workPlans.length > 0) {
+      cleaned.workPlans = msg.workPlans.map(
+        ({ isExpanded: _, ...rest }) => rest,
+      );
+    }
+
+    return cleaned;
+  });
+}
+
+export function exportSessionAsJSON(
+  messages: Message[],
+  sessionTitle?: string,
+): string {
+  const payload = {
+    exportedAt: new Date().toISOString(),
+    sessionTitle: sessionTitle || null,
+    messages: stripUiFields(messages),
+  };
+
+  return JSON.stringify(payload, null, 2);
+}
+
+// ---------------------------------------------------------------------------
+// Filename helper
+// ---------------------------------------------------------------------------
+
+export function buildExportFilename(
+  sessionTitle: string | undefined,
+  extension: "md" | "json",
+): string {
+  const datePart = new Date().toISOString().slice(0, 10);
+  const slug = sessionTitle
+    ? sessionTitle
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "")
+        .slice(0, 40)
+    : "chat";
+  return `${slug}-export-${datePart}.${extension}`;
+}

--- a/ui/client/src/components/agentic-ai/graphs/GraphCreation.tsx
+++ b/ui/client/src/components/agentic-ai/graphs/GraphCreation.tsx
@@ -563,8 +563,8 @@ const GraphCreation: React.FC<GraphCreationProps> = ({
         <CardContent className="p-0 h-full relative">
           {/* YAML debug panel */}
           {showYamlDebug && yamlFlow && (
-            <div className="absolute top-4 right-4 z-50 bg-gray-900 border border-gray-700 rounded-lg p-4 max-w-md max-h-96 overflow-auto">
-              <div className="flex justify-between items-center mb-2">
+            <div className="absolute top-4 right-4 z-50 bg-gray-900 border border-gray-700 rounded-lg max-w-md max-h-96 flex flex-col overflow-hidden">
+              <div className="flex justify-between items-center px-4 pt-4 pb-2 flex-shrink-0 border-b border-gray-700">
                 <h3 className="text-sm font-medium text-white">
                   YAML Flow State
                 </h3>
@@ -577,7 +577,7 @@ const GraphCreation: React.FC<GraphCreationProps> = ({
                   <X className="w-4 h-4" />
                 </button>
               </div>
-              <pre className="text-xs text-gray-300 overflow-auto">
+              <pre className="text-xs text-gray-300 overflow-auto p-4 flex-1 min-h-0">
                 {yaml.dump(yamlFlow, { indent: 2, lineWidth: -1 })}
               </pre>
             </div>

--- a/ui/client/src/components/agentic-ai/workspace/ElementData.tsx
+++ b/ui/client/src/components/agentic-ai/workspace/ElementData.tsx
@@ -36,8 +36,8 @@ export const ElementData: React.FC<ElementDataProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-background-card border-gray-800 text-foreground max-w-2xl max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="bg-background-card border-gray-800 text-foreground max-w-2xl max-h-[80vh] flex flex-col overflow-hidden p-0 gap-0">
+        <DialogHeader className="px-6 pt-6 pb-4 flex-shrink-0 border-b border-gray-800">
           <DialogTitle className="flex items-center gap-2">
             <FileText className="h-5 w-5 text-primary" />
             {element?.name || `${elementType.name} Details`}
@@ -45,64 +45,66 @@ export const ElementData: React.FC<ElementDataProps> = ({
         </DialogHeader>
         
         {element && (
-          <div className="space-y-4">
-            {/* Basic Info */}
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="text-sm font-medium text-gray-400">Resource ID</label>
-                <p className="font-mono text-sm text-gray-300">{element.rid}</p>
+          <div className="flex-1 overflow-y-auto px-6 py-4 min-h-0">
+            <div className="space-y-4">
+              {/* Basic Info */}
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Resource ID</label>
+                  <p className="font-mono text-sm text-gray-300">{element.rid}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Type</label>
+                  <p className="text-sm text-gray-300">{element.type}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Version</label>
+                  <p className="text-sm text-gray-300">v{element.version || 1}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Category</label>
+                  <p className="text-sm text-gray-300">{element.category}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Created</label>
+                  <p className="text-sm text-gray-300">
+                    {element.created ? new Date(element.created).toLocaleString() : 'N/A'}
+                  </p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Last Updated</label>
+                  <p className="text-sm text-gray-300">
+                    {element.updated ? new Date(element.updated).toLocaleString() : 'N/A'}
+                  </p>
+                </div>
               </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Type</label>
-                <p className="text-sm text-gray-300">{element.type}</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Version</label>
-                <p className="text-sm text-gray-300">v{element.version || 1}</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Category</label>
-                <p className="text-sm text-gray-300">{element.category}</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Created</label>
-                <p className="text-sm text-gray-300">
-                  {element.created ? new Date(element.created).toLocaleString() : 'N/A'}
-                </p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Last Updated</label>
-                <p className="text-sm text-gray-300">
-                  {element.updated ? new Date(element.updated).toLocaleString() : 'N/A'}
-                </p>
-              </div>
+
+              {/* References */}
+              {resolvedNestedRefs && resolvedNestedRefs.length > 0 && (
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Referenced Resources</label>
+                  <div className="mt-1 space-y-1">
+                    {resolvedNestedRefs.map((ref, index) => (
+                      <Badge key={index} variant="outline" className="mr-2">
+                        {ref}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Configuration */}
+              {configWithResolvedRefs && (
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Full Configuration</label>
+                  <div className="mt-2 bg-gray-900 p-4 rounded-md">
+                    <pre className="text-xs text-gray-300 whitespace-pre-wrap overflow-x-auto">
+                      {JSON.stringify(maskSecretFieldsInConfig(configWithResolvedRefs, elementSchema?.config_schema), null, 2)}
+                    </pre>
+                  </div>
+                </div>
+              )}
             </div>
-
-            {/* References */}
-            {resolvedNestedRefs && resolvedNestedRefs.length > 0 && (
-              <div>
-                <label className="text-sm font-medium text-gray-400">Referenced Resources</label>
-                <div className="mt-1 space-y-1">
-                  {resolvedNestedRefs.map((ref, index) => (
-                    <Badge key={index} variant="outline" className="mr-2">
-                      {ref}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Configuration */}
-            {configWithResolvedRefs && (
-              <div>
-                <label className="text-sm font-medium text-gray-400">Full Configuration</label>
-                <div className="mt-2 bg-gray-900 p-4 rounded-md">
-                  <pre className="text-xs text-gray-300 whitespace-pre-wrap overflow-x-auto">
-                    {JSON.stringify(maskSecretFieldsInConfig(configWithResolvedRefs, elementSchema?.config_schema), null, 2)}
-                  </pre>
-                </div>
-              </div>
-            )}
           </div>
         )}
       </DialogContent>

--- a/ui/client/src/components/agentic-ai/workspace/ElementForm.tsx
+++ b/ui/client/src/components/agentic-ai/workspace/ElementForm.tsx
@@ -694,11 +694,11 @@ export const ElementForm: React.FC<ElementFormProps> = ({
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent
-        className="bg-background-card border-gray-800 text-foreground max-w-3xl max-h-[90vh] overflow-y-auto"
+        className="bg-background-card border-gray-800 text-foreground max-w-3xl max-h-[90vh] flex flex-col overflow-hidden p-0 gap-0"
         onInteractOutside={(e) => e.preventDefault()}
         onEscapeKeyDown={(e) => e.preventDefault()}
       >
-        <DialogHeader>
+        <DialogHeader className="px-6 pt-6 pb-4 flex-shrink-0 border-b border-gray-800">
           <DialogTitle>
             {editingElement ? "Edit" : "Create"} {elementType.name}
           </DialogTitle>
@@ -710,61 +710,63 @@ export const ElementForm: React.FC<ElementFormProps> = ({
             e.preventDefault();
             handleSave();
           }}
-          className="space-y-4"
+          className="flex flex-col flex-1 min-h-0"
         >
-          {/* Render fields from combined schema */}
-          {Object.entries(elementSchema.config_schema.properties)
-            .filter(([fieldName, fieldSchema]) => {
-              // Always exclude category and type (handled by GUI)
-              if (['category', 'type'].includes(fieldName)) {
-                return false;
-              }
+          <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+            {/* Render fields from combined schema */}
+            {Object.entries(elementSchema.config_schema.properties)
+              .filter(([fieldName, fieldSchema]) => {
+                // Always exclude category and type (handled by GUI)
+                if (['category', 'type'].includes(fieldName)) {
+                  return false;
+                }
 
-              // Filter out hidden fields - check if field has hints.hidden.hint_type === "hidden"
-              if (fieldSchema?.hints?.hidden?.hint_type === "hidden") {
-                return false;
-              }
+                // Filter out hidden fields - check if field has hints.hidden.hint_type === "hidden"
+                if (fieldSchema?.hints?.hidden?.hint_type === "hidden") {
+                  return false;
+                }
 
-              // For both Create New and Edit mode: show only first-level required fields (name) + all cfg_dict fields
-              // Show first-level required fields (name is required from resource.schema)
-              const firstLevelRequiredFields = ['name'];
-              if (firstLevelRequiredFields.includes(fieldName)) {
-                return true;
-              }
+                // For both Create New and Edit mode: show only first-level required fields (name) + all cfg_dict fields
+                // Show first-level required fields (name is required from resource.schema)
+                const firstLevelRequiredFields = ['name'];
+                if (firstLevelRequiredFields.includes(fieldName)) {
+                  return true;
+                }
 
-              // Show all cfg_dict fields (element-specific config fields)
-              // These are fields that are NOT first-level fields from resource.schema
-              const firstLevelFields = ['name', 'category', 'type', 'cfg_dict', 'version', 'created', 'updated', 'nested_refs', 'rid', 'user_id'];
-              const isCfgDictField = !firstLevelFields.includes(fieldName);
-              return isCfgDictField;
+                // Show all cfg_dict fields (element-specific config fields)
+                // These are fields that are NOT first-level fields from resource.schema
+                const firstLevelFields = ['name', 'category', 'type', 'cfg_dict', 'version', 'created', 'updated', 'nested_refs', 'rid', 'user_id'];
+                const isCfgDictField = !firstLevelFields.includes(fieldName);
+                return isCfgDictField;
 
-              // Comment out the old edit mode logic that showed extra fields
-              // // For Edit mode: show all fields (except category/type)
-              // if (editingElement) {
-              //   return true;
-              // }
-            })
-            .sort(([fieldNameA, fieldSchemaA], [fieldNameB, fieldSchemaB]) => {
-              // Sort fields so that fields with dependencies come after their dependency fields
-              const populateHintA = fieldSchemaA?.hints?.action?.hint_type === 'populate' ? fieldSchemaA.hints.action : null;
-              const populateHintB = fieldSchemaB?.hints?.action?.hint_type === 'populate' ? fieldSchemaB.hints.action : null;
-              
-              // If A depends on B, A should come after B
-              if (populateHintA?.dependencies && Object.keys(populateHintA.dependencies).includes(fieldNameB)) {
-                return 1; // A comes after B
-              }
-              
-              // If B depends on A, B should come after A
-              if (populateHintB?.dependencies && Object.keys(populateHintB.dependencies).includes(fieldNameA)) {
-                return -1; // A comes before B
-              }
-              
-              // Otherwise, maintain original order
-              return 0;
-            })
-            .map(([fieldName, fieldSchema]) => renderFormField(fieldName, fieldSchema))}
+                // Comment out the old edit mode logic that showed extra fields
+                // // For Edit mode: show all fields (except category/type)
+                // if (editingElement) {
+                //   return true;
+                // }
+              })
+              .sort(([fieldNameA, fieldSchemaA], [fieldNameB, fieldSchemaB]) => {
+                // Sort fields so that fields with dependencies come after their dependency fields
+                const populateHintA = fieldSchemaA?.hints?.action?.hint_type === 'populate' ? fieldSchemaA.hints.action : null;
+                const populateHintB = fieldSchemaB?.hints?.action?.hint_type === 'populate' ? fieldSchemaB.hints.action : null;
+                
+                // If A depends on B, A should come after B
+                if (populateHintA?.dependencies && Object.keys(populateHintA.dependencies).includes(fieldNameB)) {
+                  return 1; // A comes after B
+                }
+                
+                // If B depends on A, B should come after A
+                if (populateHintB?.dependencies && Object.keys(populateHintB.dependencies).includes(fieldNameA)) {
+                  return -1; // A comes before B
+                }
+                
+                // Otherwise, maintain original order
+                return 0;
+              })
+              .map(([fieldName, fieldSchema]) => renderFormField(fieldName, fieldSchema))}
+          </div>
 
-          <DialogFooter className="mt-6">
+          <DialogFooter className="px-6 pb-6 pt-4 flex-shrink-0 border-t border-gray-800">
             <Button type="button" variant="outline" onClick={onClose}>
               Cancel
             </Button>

--- a/ui/client/src/components/agentic-ai/workspace/ValidationResultModal.tsx
+++ b/ui/client/src/components/agentic-ai/workspace/ValidationResultModal.tsx
@@ -197,8 +197,8 @@ export const ValidationResultModal: React.FC<ValidationResultModalProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-background-card border-gray-800 text-foreground max-w-2xl max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="bg-background-card border-gray-800 text-foreground max-w-2xl max-h-[80vh] flex flex-col overflow-hidden p-0 gap-0">
+        <DialogHeader className="px-6 pt-6 pb-4 flex-shrink-0 border-b border-gray-800">
           <DialogTitle className="flex items-center gap-3">
             {validationResult.is_valid ? (
               <CheckCircle2 className="h-6 w-6 text-green-500" />
@@ -209,101 +209,103 @@ export const ValidationResultModal: React.FC<ValidationResultModalProps> = ({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-6">
-          {/* Summary Section */}
-          <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-900/50 border border-gray-800">
-            <div className="flex-1">
-              <div className="flex items-center gap-2 mb-2">
-                <span className="text-sm font-medium text-gray-400">Status:</span>
-                {validationResult.is_valid ? (
-                  <Badge className="bg-green-500/20 text-green-400 border-green-500/30">
-                    Valid
-                  </Badge>
-                ) : (
-                  <Badge className="bg-red-500/20 text-red-400 border-red-500/30">
-                    Invalid
-                  </Badge>
-                )}
-              </div>
-              <div className="flex items-center gap-2 text-xs text-gray-500">
-                <span>Type: {validationResult.element_type}</span>
-                <span>•</span>
-                <span className="font-mono">{validationResult.element_rid.slice(0, 12)}...</span>
-              </div>
-            </div>
-            
-            <div className="flex items-center gap-4">
-              <div className="flex gap-3">
-                {errorCount > 0 && (
-                  <div className="flex items-center gap-1">
-                    <XCircle className="h-4 w-4 text-red-500" />
-                    <span className="text-sm text-red-400">{errorCount}</span>
-                  </div>
-                )}
-                {warningCount > 0 && (
-                  <div className="flex items-center gap-1">
-                    <AlertTriangle className="h-4 w-4 text-yellow-500" />
-                    <span className="text-sm text-yellow-400">{warningCount}</span>
-                  </div>
-                )}
-                {infoCount > 0 && (
-                  <div className="flex items-center gap-1">
-                    <Info className="h-4 w-4 text-blue-500" />
-                    <span className="text-sm text-blue-400">{infoCount}</span>
-                  </div>
-                )}
+        <div className="flex-1 overflow-y-auto px-6 py-6 min-h-0">
+          <div className="space-y-6">
+            {/* Summary Section */}
+            <div className="flex items-center gap-4 p-4 rounded-lg bg-gray-900/50 border border-gray-800">
+              <div className="flex-1">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-sm font-medium text-gray-400">Status:</span>
+                  {validationResult.is_valid ? (
+                    <Badge className="bg-green-500/20 text-green-400 border-green-500/30">
+                      Valid
+                    </Badge>
+                  ) : (
+                    <Badge className="bg-red-500/20 text-red-400 border-red-500/30">
+                      Invalid
+                    </Badge>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 text-xs text-gray-500">
+                  <span>Type: {validationResult.element_type}</span>
+                  <span>•</span>
+                  <span className="font-mono">{validationResult.element_rid.slice(0, 12)}...</span>
+                </div>
               </div>
               
-              {showRefreshButton && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleRefreshValidation}
-                  className="h-8 px-3 hover:bg-gray-700 border-gray-700"
-                  title="Re-validate resource"
-                >
-                  <RefreshCw className="h-4 w-4 mr-2" />
-                  Refresh
-                </Button>
-              )}
-            </div>
-          </div>
-
-          {/* Messages Section */}
-          {validationResult.messages.length > 0 && (
-            <div>
-              <h3 className="text-sm font-medium text-gray-400 mb-3">Messages</h3>
-              <div className="space-y-2">
-                {validationResult.messages.map((message, idx) => (
-                  <ValidationMessageItem key={idx} message={message} />
-                ))}
+              <div className="flex items-center gap-4">
+                <div className="flex gap-3">
+                  {errorCount > 0 && (
+                    <div className="flex items-center gap-1">
+                      <XCircle className="h-4 w-4 text-red-500" />
+                      <span className="text-sm text-red-400">{errorCount}</span>
+                    </div>
+                  )}
+                  {warningCount > 0 && (
+                    <div className="flex items-center gap-1">
+                      <AlertTriangle className="h-4 w-4 text-yellow-500" />
+                      <span className="text-sm text-yellow-400">{warningCount}</span>
+                    </div>
+                  )}
+                  {infoCount > 0 && (
+                    <div className="flex items-center gap-1">
+                      <Info className="h-4 w-4 text-blue-500" />
+                      <span className="text-sm text-blue-400">{infoCount}</span>
+                    </div>
+                  )}
+                </div>
+                
+                {showRefreshButton && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleRefreshValidation}
+                    className="h-8 px-3 hover:bg-gray-700 border-gray-700"
+                    title="Re-validate resource"
+                  >
+                    <RefreshCw className="h-4 w-4 mr-2" />
+                    Refresh
+                  </Button>
+                )}
               </div>
             </div>
-          )}
 
-          {/* Dependencies Section */}
-          {hasDependencies && (
-            <div>
-              <h3 className="text-sm font-medium text-gray-400 mb-3">
-                Dependencies ({Object.keys(validationResult.dependency_results).length})
-              </h3>
-              <div className="border border-gray-800 rounded-lg p-4 bg-gray-900/30">
-                <div className="space-y-1">
-                  {Object.entries(validationResult.dependency_results).map(([rid, depResult]) => (
-                    <DependencyResultItem key={rid} result={depResult} />
+            {/* Messages Section */}
+            {validationResult.messages.length > 0 && (
+              <div>
+                <h3 className="text-sm font-medium text-gray-400 mb-3">Messages</h3>
+                <div className="space-y-2">
+                  {validationResult.messages.map((message, idx) => (
+                    <ValidationMessageItem key={idx} message={message} />
                   ))}
                 </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {/* Empty state for no messages */}
-          {validationResult.messages.length === 0 && !hasDependencies && (
-            <div className="text-center py-8 text-gray-500">
-              <CheckCircle2 className="h-12 w-12 mx-auto mb-3 opacity-50" />
-              <p>No validation messages or dependencies to display.</p>
-            </div>
-          )}
+            {/* Dependencies Section */}
+            {hasDependencies && (
+              <div>
+                <h3 className="text-sm font-medium text-gray-400 mb-3">
+                  Dependencies ({Object.keys(validationResult.dependency_results).length})
+                </h3>
+                <div className="border border-gray-800 rounded-lg p-4 bg-gray-900/30">
+                  <div className="space-y-1">
+                    {Object.entries(validationResult.dependency_results).map(([rid, depResult]) => (
+                      <DependencyResultItem key={rid} result={depResult} />
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Empty state for no messages */}
+            {validationResult.messages.length === 0 && !hasDependencies && (
+              <div className="text-center py-8 text-gray-500">
+                <CheckCircle2 className="h-12 w-12 mx-auto mb-3 opacity-50" />
+                <p>No validation messages or dependencies to display.</p>
+              </div>
+            )}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/ui/client/src/pages/AgentRepository.tsx
+++ b/ui/client/src/pages/AgentRepository.tsx
@@ -127,7 +127,7 @@ export default function UserWorkspace() {
               <div className="flex flex-col h-full">
                 {/* Header with Create Button */}
                 {selectedElementType && (
-                  <div className="flex justify-between items-center mb-6">
+                  <div className="flex justify-between items-center mb-6 sticky top-0 z-10 pb-4 pt-px -mt-px bg-[hsl(var(--background-dark))] shadow-[0_4px_12px_-2px_rgba(0,0,0,0.4)]">
                     <div>
                       <h2 className="text-2xl font-heading font-bold">
                         {selectedElementType.name} Instances

--- a/ui/client/src/workspace/ResourceDetailsModal.tsx
+++ b/ui/client/src/workspace/ResourceDetailsModal.tsx
@@ -46,8 +46,8 @@ const ResourceDetailsModal: React.FC<ResourceDetailsModalProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="bg-background-card border-gray-800 text-foreground max-w-2xl max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
+      <DialogContent className="bg-background-card border-gray-800 text-foreground max-w-2xl max-h-[80vh] flex flex-col overflow-hidden p-0 gap-0">
+        <DialogHeader className="px-6 pt-6 pb-4 flex-shrink-0 border-b border-gray-800">
           <DialogTitle className="flex items-center gap-2">
             <FileText className="h-5 w-5 text-primary" />
             {element?.label || 'Resource Details'}
@@ -55,71 +55,73 @@ const ResourceDetailsModal: React.FC<ResourceDetailsModalProps> = ({
         </DialogHeader>
         
         {element?.workspaceData && (
-          <div className="space-y-4">
-            {/* Basic Info */}
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="text-sm font-medium text-gray-400">Resource ID</label>
-                <p className="font-mono text-sm text-gray-300">{element.workspaceData.rid}</p>
+          <div className="flex-1 overflow-y-auto px-6 py-4 min-h-0">
+            <div className="space-y-4">
+              {/* Basic Info */}
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Resource ID</label>
+                  <p className="font-mono text-sm text-gray-300">{element.workspaceData.rid}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Type</label>
+                  <p className="text-sm text-gray-300">{element.workspaceData.type}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Version</label>
+                  <p className="text-sm text-gray-300">v{element.workspaceData.version || 1}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Category</label>
+                  <p className="text-sm text-gray-300">{element.workspaceData.category}</p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Created</label>
+                  <p className="text-sm text-gray-300">
+                    {element.workspaceData.created ? new Date(element.workspaceData.created).toLocaleString() : 'N/A'}
+                  </p>
+                </div>
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Last Updated</label>
+                  <p className="text-sm text-gray-300">
+                    {element.workspaceData.updated ? new Date(element.workspaceData.updated).toLocaleString() : 'N/A'}
+                  </p>
+                </div>
               </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Type</label>
-                <p className="text-sm text-gray-300">{element.workspaceData.type}</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Version</label>
-                <p className="text-sm text-gray-300">v{element.workspaceData.version || 1}</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Category</label>
-                <p className="text-sm text-gray-300">{element.workspaceData.category}</p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Created</label>
-                <p className="text-sm text-gray-300">
-                  {element.workspaceData.created ? new Date(element.workspaceData.created).toLocaleString() : 'N/A'}
-                </p>
-              </div>
-              <div>
-                <label className="text-sm font-medium text-gray-400">Last Updated</label>
-                <p className="text-sm text-gray-300">
-                  {element.workspaceData.updated ? new Date(element.workspaceData.updated).toLocaleString() : 'N/A'}
-                </p>
-              </div>
+
+              {/* References */}
+              {element.workspaceData.nested_refs && element.workspaceData.nested_refs.length > 0 && (
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Referenced Resources</label>
+                  <div className="mt-1 space-y-1">
+                    {element.workspaceData.nested_refs.map((ref, index) => (
+                      <Badge key={index} variant="outline" className="mr-2">
+                        {getResourceName(ref)}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Configuration */}
+              {element.workspaceData.config && (
+                <div>
+                  <label className="text-sm font-medium text-gray-400">Full Configuration</label>
+                  <div className="mt-2 bg-gray-900 p-4 rounded-md">
+                    <pre className="text-xs text-gray-300 whitespace-pre-wrap overflow-x-auto">
+                      {JSON.stringify(
+                        maskSecretFieldsInConfig(
+                          simplifyConfigForDisplay(resolveRefsInConfig(element.workspaceData.config)), 
+                          elementSchema?.config_schema
+                        ), 
+                        null, 
+                        2
+                      )}
+                    </pre>
+                  </div>
+                </div>
+              )}
             </div>
-
-            {/* References */}
-            {element.workspaceData.nested_refs && element.workspaceData.nested_refs.length > 0 && (
-              <div>
-                <label className="text-sm font-medium text-gray-400">Referenced Resources</label>
-                <div className="mt-1 space-y-1">
-                  {element.workspaceData.nested_refs.map((ref, index) => (
-                    <Badge key={index} variant="outline" className="mr-2">
-                      {getResourceName(ref)}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Configuration */}
-            {element.workspaceData.config && (
-              <div>
-                <label className="text-sm font-medium text-gray-400">Full Configuration</label>
-                <div className="mt-2 bg-gray-900 p-4 rounded-md">
-                  <pre className="text-xs text-gray-300 whitespace-pre-wrap overflow-x-auto">
-                    {JSON.stringify(
-                      maskSecretFieldsInConfig(
-                        simplifyConfigForDisplay(resolveRefsInConfig(element.workspaceData.config)), 
-                        elementSchema?.config_schema
-                      ), 
-                      null, 
-                      2
-                    )}
-                  </pre>
-                </div>
-              </div>
-            )}
           </div>
         )}
       </DialogContent>


### PR DESCRIPTION
Allowing the user to export a chat session:

<img width="462" height="169" alt="image" src="https://github.com/user-attachments/assets/056dca79-fe8e-4cca-b043-b80fff8f6b8a" />

[chat-export-2026-04-05 (2).md](https://github.com/user-attachments/files/26487287/chat-export-2026-04-05.2.md)


[chat-export-2026-04-05 (1).json](https://github.com/user-attachments/files/26487289/chat-export-2026-04-05.1.json)


In addition, I added sticky headers for the category titles, the X button on the configure modal, and the X buton on the yaml box (GENIE-1413 and GENIE-1418).

<img width="2244" height="1157" alt="image" src="https://github.com/user-attachments/assets/31e6db72-c237-4b86-bed5-aaa1f538d4cc" />

<img width="905" height="1261" alt="image" src="https://github.com/user-attachments/assets/69e08a17-0f52-4730-82ab-9944417f3265" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat export: download sessions as Markdown or JSON with auto-generated filenames; export option available from the chat header (disabled when no messages).

* **UI/UX Improvements**
  * Dialogs and panels updated to use fixed headers with independently scrollable content for more stable layouts.
  * YAML/debug panel sizing improved for better content fit.
  * Selected element type header in Agent Repository is now sticky for easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->