### PR TITLE
GENIE-1151/story/name-duplication-logic

### DIFF
--- a/ui/client/src/components/agentic-ai/workspace/ElementForm.tsx
+++ b/ui/client/src/components/agentic-ai/workspace/ElementForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
   Dialog,
   DialogContent,
@@ -26,7 +26,8 @@ interface ElementFormProps {
   elementSchema: ElementSchema;
   elementActions?: any[];
   editingElement: ElementInstance | null;
-  onSave: (data: any) => Promise<void>;
+  onSave: (data: any) => Promise<any>;
+  existingNames?: string[];
 }
 
 export const ElementForm: React.FC<ElementFormProps> = ({
@@ -37,6 +38,7 @@ export const ElementForm: React.FC<ElementFormProps> = ({
   elementActions = [],
   editingElement,
   onSave,
+  existingNames = [],
 }) => {
   const [formData, setFormData] = useState<any>({});
   const [isSaving, setIsSaving] = useState(false);
@@ -49,6 +51,26 @@ export const ElementForm: React.FC<ElementFormProps> = ({
   const [populateResults, setPopulateResults] = useState<{ [fieldName: string]: string[] | any }>({});
 
   const { fetchResourcesForCategory } = useWorkspaceData();
+
+  const existingNamesSet = useMemo(
+    () => new Set(existingNames.map(n => n.toLowerCase())),
+    [existingNames]
+  );
+
+  const nameError = useMemo(() => {
+    const currentName = formData.name?.trim();
+    if (!currentName) return null;
+
+    if (editingElement?.name && editingElement.name.toLowerCase() === currentName.toLowerCase()) {
+      return null;
+    }
+
+    if (existingNamesSet.has(currentName.toLowerCase())) {
+      return `A ${elementType.name} named "${currentName}" already exists. Please choose a different name.`;
+    }
+
+    return null;
+  }, [formData.name, existingNamesSet, editingElement, elementType.name]);
 
   // Helper to check if a field has validation hint
   const fieldHasValidation = useCallback((fieldName: string): boolean => {
@@ -499,7 +521,7 @@ export const ElementForm: React.FC<ElementFormProps> = ({
     // This handles both required and non-required fields with validation hints (ActionHint or ApiHint)
     const noFailedValidations = !Object.values(fieldValidationStates).some(isValid => isValid === false);
 
-    return allRequiredFieldsValid && noFailedValidations;
+    return allRequiredFieldsValid && noFailedValidations && !nameError;
   };
 
   const handleSave = async () => {
@@ -762,7 +784,17 @@ export const ElementForm: React.FC<ElementFormProps> = ({
               // Otherwise, maintain original order
               return 0;
             })
-            .map(([fieldName, fieldSchema]) => renderFormField(fieldName, fieldSchema))}
+            .map(([fieldName, fieldSchema]) => {
+              if (fieldName === 'name' && nameError) {
+                return (
+                  <React.Fragment key={fieldName}>
+                    {renderFormField(fieldName, fieldSchema)}
+                    <p className="text-red-400 text-sm -mt-2">{nameError}</p>
+                  </React.Fragment>
+                );
+              }
+              return renderFormField(fieldName, fieldSchema);
+            })}
 
           <DialogFooter className="mt-6">
             <Button type="button" variant="outline" onClick={onClose}>

--- a/ui/client/src/pages/AgentRepository.tsx
+++ b/ui/client/src/pages/AgentRepository.tsx
@@ -64,11 +64,14 @@ export default function UserWorkspace() {
 
   const handleSaveElement = async (elementData: any) => {
     if (selectedElementType) {
-      await saveElement(selectedElementType.category, selectedElementType.type, elementData, editingElement?.rid);
-      setIsFormOpen(false);
-      // Refresh instances
-      fetchElementInstances(selectedElementType.category, selectedElementType.type);
+      const result = await saveElement(selectedElementType.category, selectedElementType.type, elementData, editingElement?.rid);
+      if (result) {
+        setIsFormOpen(false);
+        fetchElementInstances(selectedElementType.category, selectedElementType.type);
+      }
+      return result;
     }
+    return null;
   };
 
   const handleDeleteElement = (rid: string) => {
@@ -200,6 +203,7 @@ export default function UserWorkspace() {
               elementActions={elementActions}
               editingElement={editingElement}
               onSave={handleSaveElement}
+              existingNames={elementInstances.map(el => el.name).filter((name): name is string => !!name)}
             />
           )}
         </main>


### PR DESCRIPTION
currently, when a user creates or edits an inventory object and enters a name that already exists, he gets the feedback in an error toast after clicking save. by then, the form closes and all configuration he made is lost. this can be really frustrating for bigger objects where the user has spent time filling in urls, api keys, system messages, etc.

for this, i added real-time inline validation on the name field that checks against existing element names (case-insensitive) and displays an error message directly below the field. the save button is disabled while a duplicate name is detected. also, when editing an existing element, its own current name is excluded from the duplicate check.

<img width="709" height="137" alt="image" src="https://github.com/user-attachments/assets/1661e3b2-0a90-4300-8bc1-bfbdfa239310" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent duplicate element names in forms; error messages now display when a name already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->