### PR TITLE
GENIE-1151/story/inline-name-duplicate-validation

### DIFF
--- a/ui/client/src/components/agentic-ai/workspace/ElementForm.tsx
+++ b/ui/client/src/components/agentic-ai/workspace/ElementForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import {
   Dialog,
   DialogContent,
@@ -19,6 +19,10 @@ import { ItemValidationResult } from "./FieldValidation";
 import { UmamiTrack } from '@/components/ui/umamitrack';
 import { UmamiEvents } from '@/config/umamiEvents';
 
+function normalizeElementName(v: string): string {
+  return v.trim().toLowerCase();
+}
+
 interface ElementFormProps {
   isOpen: boolean;
   onClose: () => void;
@@ -26,7 +30,9 @@ interface ElementFormProps {
   elementSchema: ElementSchema;
   elementActions?: any[];
   editingElement: ElementInstance | null;
-  onSave: (data: any) => Promise<void>;
+  /** Names of other instances of this element type (used for duplicate name checks). */
+  existingNames?: string[];
+  onSave: (data: any) => Promise<unknown>;
 }
 
 export const ElementForm: React.FC<ElementFormProps> = ({
@@ -36,6 +42,7 @@ export const ElementForm: React.FC<ElementFormProps> = ({
   elementSchema,
   elementActions = [],
   editingElement,
+  existingNames = [],
   onSave,
 }) => {
   const [formData, setFormData] = useState<any>({});
@@ -49,6 +56,35 @@ export const ElementForm: React.FC<ElementFormProps> = ({
   const [populateResults, setPopulateResults] = useState<{ [fieldName: string]: string[] | any }>({});
 
   const { fetchResourcesForCategory } = useWorkspaceData();
+
+  const existingNamesSet = useMemo(
+    () =>
+      new Set(
+        existingNames
+          .map((n) => normalizeElementName(n))
+          .filter((n) => n.length > 0),
+      ),
+    [existingNames],
+  );
+
+  const nameError = useMemo(() => {
+    const raw = formData.name;
+    if (typeof raw !== "string") return null;
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+
+    if (
+      editingElement?.name &&
+      normalizeElementName(editingElement.name) === normalizeElementName(raw)
+    ) {
+      return null;
+    }
+
+    if (existingNamesSet.has(normalizeElementName(raw))) {
+      return `A ${elementType.name} named "${trimmed}" already exists. Please choose a different name.`;
+    }
+    return null;
+  }, [formData.name, existingNamesSet, editingElement?.name, elementType.name]);
 
   // Helper to check if a field has validation hint
   const fieldHasValidation = useCallback((fieldName: string): boolean => {
@@ -499,12 +535,16 @@ export const ElementForm: React.FC<ElementFormProps> = ({
     // This handles both required and non-required fields with validation hints (ActionHint or ApiHint)
     const noFailedValidations = !Object.values(fieldValidationStates).some(isValid => isValid === false);
 
-    return allRequiredFieldsValid && noFailedValidations;
+    return allRequiredFieldsValid && noFailedValidations && !nameError;
   };
 
   const handleSave = async () => {
     try {
       setIsSaving(true);
+
+      if (nameError) {
+        return;
+      }
 
       // Validate all required fields from combined schema, excluding hidden fields
       const required = elementSchema.config_schema.required || [];
@@ -632,8 +672,7 @@ export const ElementForm: React.FC<ElementFormProps> = ({
 
       const result = await onSave(saveData);
 
-      // Only close the dialog if save was successful (result is not null/false)
-      if (result !== null) {
+      if (result) {
         onClose();
       }
     } catch (error) {
@@ -763,7 +802,14 @@ export const ElementForm: React.FC<ElementFormProps> = ({
                 // Otherwise, maintain original order
                 return 0;
               })
-              .map(([fieldName, fieldSchema]) => renderFormField(fieldName, fieldSchema))}
+              .map(([fieldName, fieldSchema]) => (
+                <div key={fieldName}>
+                  {renderFormField(fieldName, fieldSchema)}
+                  {fieldName === "name" && nameError ? (
+                    <p className="text-destructive text-sm mt-1">{nameError}</p>
+                  ) : null}
+                </div>
+              ))}
           </div>
 
           <DialogFooter className="px-6 pb-6 pt-4 flex-shrink-0 border-t border-gray-800">

--- a/ui/client/src/pages/AgentRepository.tsx
+++ b/ui/client/src/pages/AgentRepository.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import Sidebar from "@/components/layout/Sidebar";
 import Header from "@/components/layout/Header";
 import { Button } from "@/components/ui/button";
@@ -62,13 +62,26 @@ export default function UserWorkspace() {
     setIsFormOpen(true);
   };
 
+  const existingNames = useMemo(
+    () =>
+      elementInstances
+        .map((el) => el.name)
+        .filter((name): name is string => !!name),
+    [elementInstances],
+  );
+
   const handleSaveElement = async (elementData: any) => {
-    if (selectedElementType) {
-      await saveElement(selectedElementType.category, selectedElementType.type, elementData, editingElement?.rid);
-      setIsFormOpen(false);
-      // Refresh instances
+    if (!selectedElementType) return null;
+    const result = await saveElement(
+      selectedElementType.category,
+      selectedElementType.type,
+      elementData,
+      editingElement?.rid,
+    );
+    if (result) {
       fetchElementInstances(selectedElementType.category, selectedElementType.type);
     }
+    return result;
   };
 
   const handleDeleteElement = (rid: string) => {
@@ -199,6 +212,7 @@ export default function UserWorkspace() {
               elementSchema={elementSchema}
               elementActions={elementActions}
               editingElement={editingElement}
+              existingNames={existingNames}
               onSave={handleSaveElement}
             />
           )}


### PR DESCRIPTION
currently, when a user creates or edits an inventory object and enters a name that already exists, he gets the feedback in an error toast after clicking save. by then, the form closes and all configuration he made is lost. this can be really frustrating for bigger objects where the user has spent time filling in urls, api keys, system messages, etc.

for this, i added real-time inline validation on the name field that checks against existing element names (case-insensitive) and displays an error message directly below the field. the save button is disabled while a duplicate name is detected. also, when editing an existing element, its own current name is excluded from the duplicate check.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Element forms now validate names to prevent duplicates, displaying clear error messages when conflicts are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->