### PR TITLE
bug fix

### DIFF
--- a/multi-agent/lib/mas/actions/providers/mcp/get_tools_names/get_tools_names.py
+++ b/multi-agent/lib/mas/actions/providers/mcp/get_tools_names/get_tools_names.py
@@ -80,10 +80,9 @@ class GetToolsNamesAction(BaseAction):
             )
 
             auth = None
-            if self._auth_service and input_data.user_id and input_data.server_identifier:
-                auth = self._auth_service.bind(
-                    input_data.user_id, input_data.server_identifier,
-                )
+            if self._auth_service and input_data.user_id:
+                lookup_id = input_data.server_identifier or str(input_data.mcp_url)
+                auth = self._auth_service.bind(input_data.user_id, lookup_id)
 
             provider = await self._factory.create_async(config, auth_credential=auth)
             tools = provider.get_tools()

--- a/multi-agent/lib/mas/actions/providers/mcp/validate_connection/validate_connection.py
+++ b/multi-agent/lib/mas/actions/providers/mcp/validate_connection/validate_connection.py
@@ -90,8 +90,9 @@ class ValidateConnectionAction(BaseAction):
         auth_method = input_data.auth_method
 
         auth_cred = None
-        if auth_method != "access_token" and self._auth and user_id and server_id:
-            auth_cred = self._auth.bind(user_id, server_id)
+        if self._auth and user_id and not input_data.bearer_token:
+            lookup_id = server_id or str(input_data.mcp_url)
+            auth_cred = self._auth.bind(user_id, lookup_id)
 
         config = McpProviderConfig(
             mcp_url=input_data.mcp_url,
@@ -105,6 +106,9 @@ class ValidateConnectionAction(BaseAction):
             with anyio.fail_after(10.0):
                 await self._factory.create_async(config, auth_credential=auth_cred)
             elapsed = (time.time() - start) * 1000
+
+            if auth_method == "access_token":
+                self._establish_credential(input_data)
 
             return ValidateConnectionOutput(
                 success=True, message=f"Connected ({elapsed:.0f}ms)",
@@ -128,6 +132,30 @@ class ValidateConnectionAction(BaseAction):
                 is_reachable=False,
                 response_time_ms=(time.time() - start) * 1000,
             )
+
+    def _establish_credential(self, input_data: ValidateConnectionInput) -> None:
+        """Persist a validated bearer token to the credential store.
+
+        Called after a successful connection proves the token is valid.
+        Ensures subsequent operations (get_tools, resource validation,
+        runtime execution) can retrieve the credential by mcp_url.
+        """
+        if not input_data.bearer_token or not self._auth or not input_data.user_id:
+            return
+
+        try:
+            from mas.core.auth.credentials.models import StoredCredential, TokenStatus
+
+            self._auth.save_credential(StoredCredential(
+                user_id=input_data.user_id,
+                server_identifier=str(input_data.mcp_url),
+                access_token=input_data.bearer_token,
+                scheme_type="api_key",
+                status=TokenStatus.ACTIVE,
+                expires_at=None,
+            ))
+        except Exception as exc:
+            logger.warning("Failed to establish credential: %s", exc)
 
     def _handle_auth_required_sync(
         self, input_data: ValidateConnectionInput,

--- a/multi-agent/lib/mas/actions/providers/mcp/validate_connection/validate_connection.py
+++ b/multi-agent/lib/mas/actions/providers/mcp/validate_connection/validate_connection.py
@@ -105,12 +105,13 @@ class ValidateConnectionAction(BaseAction):
             with anyio.fail_after(10.0):
                 await self._factory.create_async(config, auth_credential=auth_cred)
             elapsed = (time.time() - start) * 1000
+
             return ValidateConnectionOutput(
                 success=True, message=f"Connected ({elapsed:.0f}ms)",
                 is_reachable=True,
                 authenticated=bool(auth_cred) or bool(input_data.bearer_token),
                 status="authenticated" if (auth_cred or input_data.bearer_token) else "",
-                server_identifier=server_id,
+                server_identifier=server_id or str(input_data.mcp_url),
                 response_time_ms=elapsed,
             )
 

--- a/multi-agent/lib/mas/actions/providers/mcp/validate_connection/validate_connection.py
+++ b/multi-agent/lib/mas/actions/providers/mcp/validate_connection/validate_connection.py
@@ -93,7 +93,7 @@ class ValidateConnectionAction(BaseAction):
         scheme_type = input_data.scheme_type
 
         auth_cred = None
-        if self._auth and user_id and not input_data.bearer_token:
+        if auth_method != "access_token" and self._auth and user_id and not input_data.bearer_token:
             lookup_id = server_id or str(input_data.mcp_url)
             auth_cred = self._auth.bind(user_id, lookup_id, scheme_type=scheme_type)
 

--- a/multi-agent/lib/mas/actions/providers/mcp/validate_connection/validate_connection.py
+++ b/multi-agent/lib/mas/actions/providers/mcp/validate_connection/validate_connection.py
@@ -31,6 +31,7 @@ class ValidateConnectionInput(BaseActionInput):
     server_identifier: str = Field(default="")
     bearer_token: Optional[str] = Field(default=None)
     auth_method: str = Field(default="access_token")
+    scheme_type: str = Field(default="")
     transport_type: McpTransportType = Field(default=McpTransportType.STREAMABLE_HTTP)
     additional_headers: Dict[str, Any] = Field(default_factory=dict)
 
@@ -89,10 +90,12 @@ class ValidateConnectionAction(BaseAction):
         server_id = input_data.server_identifier
         auth_method = input_data.auth_method
 
+        scheme_type = input_data.scheme_type
+
         auth_cred = None
         if self._auth and user_id and not input_data.bearer_token:
             lookup_id = server_id or str(input_data.mcp_url)
-            auth_cred = self._auth.bind(user_id, lookup_id)
+            auth_cred = self._auth.bind(user_id, lookup_id, scheme_type=scheme_type)
 
         config = McpProviderConfig(
             mcp_url=input_data.mcp_url,
@@ -167,7 +170,7 @@ class ValidateConnectionAction(BaseAction):
         auth_method = input_data.auth_method
         server_id = input_data.server_identifier
         user_id = input_data.user_id
-        scheme_type = ""
+        scheme_type = input_data.scheme_type
         scopes: List[str] = []
 
         if auth_method == "access_token":
@@ -196,7 +199,7 @@ class ValidateConnectionAction(BaseAction):
         if server_id and user_id and self._auth:
             try:
                 with get_async_bridge() as bridge:
-                    token = bridge.run(self._auth.get_valid_token(user_id, server_id))
+                    token = bridge.run(self._auth.get_valid_token(user_id, server_id, scheme_type=scheme_type))
             except Exception as exc:
                 logger.warning("Token lookup/refresh failed: %s", exc)
                 token = None
@@ -205,7 +208,7 @@ class ValidateConnectionAction(BaseAction):
                 user_id, server_id, bool(token),
             )
             if token:
-                auth_cred = self._auth.bind(user_id, server_id)
+                auth_cred = self._auth.bind(user_id, server_id, scheme_type=scheme_type)
                 config = McpProviderConfig(
                     mcp_url=input_data.mcp_url,
                     transport_type=input_data.transport_type,

--- a/multi-agent/lib/mas/actions/providers/mcp/validate_connection/validate_connection.py
+++ b/multi-agent/lib/mas/actions/providers/mcp/validate_connection/validate_connection.py
@@ -93,7 +93,7 @@ class ValidateConnectionAction(BaseAction):
         scheme_type = input_data.scheme_type
 
         auth_cred = None
-        if auth_method != "access_token" and self._auth and user_id and not input_data.bearer_token:
+        if auth_method != "access_token" and self._auth and user_id and server_id:
             lookup_id = server_id or str(input_data.mcp_url)
             auth_cred = self._auth.bind(user_id, lookup_id, scheme_type=scheme_type)
 

--- a/multi-agent/lib/mas/elements/providers/mcp_server_client/validator.py
+++ b/multi-agent/lib/mas/elements/providers/mcp_server_client/validator.py
@@ -1,20 +1,18 @@
 """
 elements/providers/mcp_server_client/validator.py
 
-Validator for MCP Provider — lightweight HTTP probe (no MCP SDK).
+Validator for MCP Provider — uses McpProviderFactory for a real connection probe.
 
-Auth-method-aware:
-  - ``access_token`` → includes ``bearer_token`` from config in the probe.
-  - ``sign_in``      → delegates to ``core/auth`` for the full token lifecycle
-                        (lookup → validity check → refresh → failure).
-  - ``none``         → probes without auth headers.
+Uses the same transport path as the wizard and runtime (McpProviderFactory),
+and resolves auth credentials via ``core/auth`` before probing.
 """
 
 import time
 import logging
-from typing import Any, Dict, List
+from concurrent.futures import CancelledError
+from typing import List
 
-import httpx
+import anyio
 from global_utils.utils.async_bridge import get_async_bridge
 from mas.elements.common.validator import (
     BaseElementValidator,
@@ -23,30 +21,23 @@ from mas.elements.common.validator import (
     ValidationMessage,
     ValidationCode,
 )
-from mas.core.auth.errors import TokenExpiredError
 from mas.elements.providers.mcp_server_client.config import McpProviderConfig
+from mas.elements.providers.mcp_server_client.mcp_provider_factory import McpProviderFactory
 
 logger = logging.getLogger(__name__)
-
-_MCP_INIT_BODY = {
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "initialize",
-    "params": {
-        "protocolVersion": "2024-11-05",
-        "capabilities": {},
-        "clientInfo": {"name": "unifai-probe", "version": "1.0"},
-    },
-}
 
 
 class McpProviderValidator(BaseElementValidator):
     """
-    Validates MCP Provider configuration via lightweight HTTP probe.
+    Validates MCP Provider configuration.
 
-    Sends a JSON-RPC initialize request directly with httpx.
-    Resolves auth headers via ``core/auth`` before probing.
+    Uses McpProviderFactory.create_async() for a real MCP connection probe,
+    matching the same transport path the wizard and runtime use.
     """
+
+    def __init__(self, factory: McpProviderFactory = None):
+        super().__init__()
+        self._factory = factory or McpProviderFactory()
 
     def validate(
         self,
@@ -57,7 +48,13 @@ class McpProviderValidator(BaseElementValidator):
 
         try:
             with get_async_bridge() as bridge:
-                bridge.run(self._probe_connection(config, context, messages))
+                bridge.run(self._check_connection(config, context, messages))
+        except (CancelledError, TimeoutError) as e:
+            messages.append(self._error(
+                ValidationCode.NETWORK_TIMEOUT.value,
+                str(e),
+                field="mcp_url",
+            ))
         except Exception as e:
             messages.append(self._error(
                 ValidationCode.ENDPOINT_UNREACHABLE.value,
@@ -67,92 +64,60 @@ class McpProviderValidator(BaseElementValidator):
 
         return self._build_report(messages=messages)
 
-    async def _probe_connection(
+    async def _check_connection(
         self,
         config: McpProviderConfig,
         context: ValidationContext,
         messages: List[ValidationMessage],
     ) -> None:
-        mcp_url = str(config.mcp_url).rstrip("/")
-        headers: Dict[str, Any] = {
-            "Content-Type": "application/json",
-            "Accept": "application/json, text/event-stream",
-        }
-
-        server_id = getattr(config, "server_identifier", "")
-        scheme_type = getattr(config, "scheme_type", "")
-
-        if server_id and context.user_id and context.auth_service:
-            try:
-                auth_headers = await context.auth_service.get_headers(
-                    context.user_id, server_id,
-                    scheme_type=scheme_type,
-                )
-                headers.update(auth_headers)
-            except TokenExpiredError:
-                messages.append(self._error(
-                    "AUTH_EXPIRED",
-                    "Authentication expired — sign in again or update your access token",
-                    field="mcp_url",
-                ))
-                return
-            except Exception as exc:
-                logger.debug("Failed to get auth headers for validation: %s", exc)
-                messages.append(self._error(
-                    "AUTH_EXPIRED",
-                    "Authentication failed — sign in again or update your access token",
-                    field="mcp_url",
-                ))
-                return
-
-        if config.additional_headers:
-            headers.update(config.additional_headers)
-
-        timeout = min(context.timeout_seconds, 10.0)
+        """
+        Async MCP connection check using McpProviderFactory.
+        
+        Uses anyio.fail_after INSIDE the async function for timeout control.
+        """
         start = time.time()
 
-        try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
-                resp = await client.post(
-                    mcp_url, json=_MCP_INIT_BODY, headers=headers,
-                )
-            elapsed = (time.time() - start) * 1000
-        except httpx.TimeoutException:
-            messages.append(self._error(
-                ValidationCode.NETWORK_TIMEOUT.value,
-                f"Connection timed out after {timeout}s",
-                field="mcp_url",
-            ))
-            return
-        except Exception as exc:
-            messages.append(self._error(
-                ValidationCode.ENDPOINT_UNREACHABLE.value,
-                f"Connection failed: {exc}",
-                field="mcp_url",
-            ))
-            return
+        auth_cred = None
+        if context.user_id and context.auth_service:
+            lookup_id = getattr(config, "server_identifier", "") or str(config.mcp_url)
+            auth_cred = context.auth_service.bind(context.user_id, lookup_id)
 
-        if 200 <= resp.status_code < 300:
+        try:
+            with anyio.fail_after(context.timeout_seconds):
+                await self._factory.create_async(config, auth_credential=auth_cred)
+
+            elapsed = (time.time() - start) * 1000
             messages.append(self._info(
                 "CONNECTION_OK",
                 f"Connected to MCP server at {config.mcp_url} ({elapsed:.0f}ms)",
                 field="mcp_url",
             ))
-        elif resp.status_code == 401:
+
+        except TimeoutError:
             messages.append(self._error(
-                ValidationCode.INVALID_CREDENTIALS.value,
-                "Server rejected the credentials — sign in again or update your access token",
+                ValidationCode.NETWORK_TIMEOUT.value,
+                f"Connection timed out after {context.timeout_seconds}s",
                 field="mcp_url",
             ))
-        elif resp.status_code == 403:
-            messages.append(self._error(
-                ValidationCode.INVALID_CREDENTIALS.value,
-                "Authenticated but not authorized — check your scopes or contact the server administrator",
-                field="mcp_url",
-            ))
-        else:
-            messages.append(self._error(
-                ValidationCode.ENDPOINT_UNREACHABLE.value,
-                f"Server returned unexpected status {resp.status_code}",
-                field="mcp_url",
-            ))
+        except RuntimeError:
+            raise
+        except Exception as e:
+            error_msg = str(e)
+            if "401" in error_msg or "Unauthorized" in error_msg:
+                messages.append(self._error(
+                    ValidationCode.INVALID_CREDENTIALS.value,
+                    "Server rejected the credentials — sign in again or update your access token",
+                    field="mcp_url",
+                ))
+            elif "403" in error_msg or "Forbidden" in error_msg:
+                messages.append(self._error(
+                    ValidationCode.INVALID_CREDENTIALS.value,
+                    "Authenticated but not authorized — check your scopes or contact the server administrator",
+                    field="mcp_url",
+                ))
+            else:
+                messages.append(self._error(
+                    ValidationCode.ENDPOINT_UNREACHABLE.value,
+                    f"Connection failed: {e}",
+                    field="mcp_url",
+                ))


### PR DESCRIPTION
Validator switched from McpProviderFactory to raw httpx.post() — SSE endpoints only accept GET, so they return 405. Also, the factory handles the MCP handshake properly (connect, get endpoint event, tear down), while raw httpx can't.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More flexible MCP authentication binding using alternate lookup when server identifier is missing
  * Added 10s timeout to MCP connection validation to avoid indefinite waits

* **Enhancements**
  * Persist bearer-token credentials after successful connection
  * Replaced HTTP probing with real MCP connection checks for more reliable validation
  * Added scheme_type support across auth, refresh, and binding flows

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-community-ai-tools/UnifAI/pull/161)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->