### PR TITLE
reduce unifai deployment secret number

### DIFF
--- a/helm/backend.yaml.gotmpl
+++ b/helm/backend.yaml.gotmpl
@@ -7,6 +7,7 @@ environments:
 helmDefaults:
   createNamespace: false
   wait: false
+  historyMax: 1
 
 releases:
 

--- a/helm/identity.yaml.gotmpl
+++ b/helm/identity.yaml.gotmpl
@@ -7,6 +7,7 @@ environments:
 helmDefaults:
   createNamespace: false
   wait: false
+  historyMax: 1
 
 releases:
 

--- a/helm/multiagent.yaml.gotmpl
+++ b/helm/multiagent.yaml.gotmpl
@@ -7,6 +7,7 @@ environments:
 helmDefaults:
   createNamespace: false
   wait: false
+  historyMax: 1
 
 releases:
 

--- a/helm/rag.yaml.gotmpl
+++ b/helm/rag.yaml.gotmpl
@@ -7,6 +7,7 @@ environments:
 helmDefaults:
   createNamespace: false
   wait: false
+  historyMax: 1
 
 releases:
 

--- a/helm/shared-resources.yaml.gotmpl
+++ b/helm/shared-resources.yaml.gotmpl
@@ -7,6 +7,7 @@ environments:
 helmDefaults:
   createNamespace: false
   wait: false
+  historyMax: 1
 
 releases:
 

--- a/helm/ui.yaml.gotmpl
+++ b/helm/ui.yaml.gotmpl
@@ -7,6 +7,7 @@ environments:
 helmDefaults:
   createNamespace: false
   wait: false
+  historyMax: 1
 
 releases:
 


### PR DESCRIPTION
when deploying unifai , helm saves former release revisions for upgrade/downgrade procedures.
since our upgrade isn't real upgrade we don't need that number of secrets and the option to go to each release etc.
adding a flag to the helm defauls will reduce this.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm release history retention across all service deployments to retain only the most recent revision, reducing storage overhead and streamlining release history management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-community-ai-tools/UnifAI/pull/166)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->