### PR TITLE
fix(session): filter cancelled messages from agent workspace context

### DIFF
--- a/multi-agent/lib/mas/elements/llms/common/chat/message.py
+++ b/multi-agent/lib/mas/elements/llms/common/chat/message.py
@@ -30,3 +30,8 @@ class ChatMessage(BaseModel):
     metadata: Dict[str, Any] = {}
 
     model_config = ConfigDict(frozen=True)
+
+    @property
+    def is_cancelled(self) -> bool:
+        """Check if this message has been marked as cancelled."""
+        return bool(self.metadata.get("is_cancelled"))

--- a/multi-agent/lib/mas/elements/nodes/common/workload/workspace_service.py
+++ b/multi-agent/lib/mas/elements/nodes/common/workload/workspace_service.py
@@ -862,8 +862,12 @@ class WorkspaceService(IWorkspaceService):
         
         Returns number of messages actually synced.
         """
-        # Extract recent messages
-        recent_messages = graphstate_messages[-limit:] if graphstate_messages else []
+        # Filter out cancelled messages, then take the most recent N
+        valid_messages = [
+            msg for msg in graphstate_messages
+            if not (hasattr(msg, 'metadata') and isinstance(msg.metadata, dict) and msg.metadata.get("is_cancelled"))
+        ] if graphstate_messages else []
+        recent_messages = valid_messages[-limit:]
         
         if not recent_messages:
             return 0

--- a/multi-agent/lib/mas/elements/nodes/common/workload/workspace_service.py
+++ b/multi-agent/lib/mas/elements/nodes/common/workload/workspace_service.py
@@ -865,7 +865,7 @@ class WorkspaceService(IWorkspaceService):
         # Filter out cancelled messages, then take the most recent N
         valid_messages = [
             msg for msg in graphstate_messages
-            if not (hasattr(msg, 'metadata') and isinstance(msg.metadata, dict) and msg.metadata.get("is_cancelled"))
+            if not msg.is_cancelled
         ] if graphstate_messages else []
         recent_messages = valid_messages[-limit:]
         


### PR DESCRIPTION
When you cancel a question and ask something new, the AI was still answering the old cancelled questions along with your new one. This happened because cancelled messages were being passed to the agents as if they were real requests. Now we filter them out — so after you cancel, only your latest question gets answered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace synchronization now correctly ignores cancelled messages so recent activity and updates no longer include messages marked cancelled.
* **New Features**
  * Messages now expose a cancellation flag so cancelled items are recognized and handled consistently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/redhat-community-ai-tools/UnifAI/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->