### PR TITLE
fixes

### DIFF
--- a/multi-agent/adapters/outbound/channels/redis/factory.py
+++ b/multi-agent/adapters/outbound/channels/redis/factory.py
@@ -28,7 +28,7 @@ class RedisChannelFactory(ChannelFactory):
         block_ms: int = 5000,
         batch_size: int = 50,
     ) -> None:
-        self._pool = ConnectionPool.from_url(redis_url)
+        self._pool = ConnectionPool.from_url(redis_url, socket_timeout=30)
         self._stream_ttl = stream_ttl
         self._block_ms = block_ms
         self._batch_size = batch_size

--- a/multi-agent/adapters/outbound/redis/collaboration_store.py
+++ b/multi-agent/adapters/outbound/redis/collaboration_store.py
@@ -97,7 +97,7 @@ def _team_edit_lock_key(team_id: str, entity_kind: str, entity_id: str) -> str:
 class RedisCollaborationStore(CollaborationStore):
 
     def __init__(self, redis_url: str) -> None:
-        self._pool = ConnectionPool.from_url(redis_url)
+        self._pool = ConnectionPool.from_url(redis_url, socket_timeout=30)
 
     def _client(self) -> Redis:
         return Redis(connection_pool=self._pool)

--- a/multi-agent/bootstrap/container.py
+++ b/multi-agent/bootstrap/container.py
@@ -150,7 +150,7 @@ class AppContainer(metaclass=SingletonMeta):
         pending_store = None
         if redis_url:
             import redis as redis_lib
-            redis_client = redis_lib.Redis.from_url(redis_url)
+            redis_client = redis_lib.Redis.from_url(redis_url, socket_timeout=30)
             pending_store = RedisFlowStateStore(
                 redis_client=redis_client,
                 encryption_key=cfg.credential_encryption_key,


### PR DESCRIPTION
- Sets `socket_timeout=30` on all Redis connection pools in multi-agent to fix session streaming hang.
- **Root cause**: `redis-py` 8.0.0 changed the default `socket_timeout` from `None` to `5s`. This causes `XREAD BLOCK 5000` to collide with the socket timeout, making the read fail/hang instead of returning an empty result after 5 seconds.
- This broke `session.subscribe` heartbeats — during agent "thinking" periods (>5s), no keepalive packets were sent, causing sessions to hang indefinitely.
## Affected files
- `multi-agent/adapters/outbound/channels/redis/factory.py`
- `multi-agent/bootstrap/container.py`
- `multi-agent/adapters/outbound/redis/collaboration_store.py`
