### PR TITLE
fixes to the deployment script

### DIFF
--- a/ci/pipeline-build-pg.groovy
+++ b/ci/pipeline-build-pg.groovy
@@ -253,15 +253,20 @@ pipeline {
             }
             steps {
                 script {
-                    def modules = []
-                    if (params.build_identity_image) modules << 'identity'
-                    if (params.build_rag_backend) modules << 'rag'
-                    if (params.build_multiagent_backend) modules << 'multiagent'
-                    if (params.build_backend) modules << 'backend'
-                    if (params.build_gui) modules << 'ui'
-                    def modulesToDeploy = modules.join(',')
 
-                    echo "Triggering deployment pipeline with MODULES_TO_DEPLOY = ${modulesToDeploy}"
+                    def identityVersion = ""
+                    def ragVersion = ""
+                    def multiagentVersion = ""
+                    def backendVersion = ""
+                    def guiVersion = ""
+                    
+                    if (params.build_identity_image) identityVersion = params.VERSION
+                    if (params.build_rag_backend) ragVersion = params.VERSION
+                    if (params.build_multiagent_backend) multiagentVersion = params.VERSION
+                    if (params.build_backend) backendVersion = params.VERSION
+                    if (params.build_gui) guiVersion = params.VERSION
+
+                    echo "Triggering deployment pipeline with IDENTITY_VERSION = ${identityVersion}, RAG_VERSION = ${ragVersion}, MULTIAGENT_VERSION = ${multiagentVersion}, BACKEND_VERSION = ${backendVersion}, GUI_VERSION = ${guiVersion}"
                     // build job: 'Unifai-playground-deploy',
                     build job: 'Unifai-playground-deploy',
                     parameters: [
@@ -269,11 +274,11 @@ pipeline {
                         string(name: 'deploy_namespace', value: params.deploy_namespace),
                         string(name: 'deploy_type', value: params.deploy_type),
                         string(name: 'BRANCH', value: params.BRANCH),
-                        string(name: 'IDENTITY_VERSION', value: params.VERSION),
-                        string(name: 'BACKEND_VERSION', value: params.VERSION),
-                        string(name: 'RAG_VERSION', value: params.VERSION),
-                        string(name: 'MA_VERSION', value: params.VERSION),
-                        string(name: 'GUI_VERSION', value: params.VERSION),
+                        string(name: 'IDENTITY_VERSION', value: identityVersion),
+                        string(name: 'BACKEND_VERSION', value: backendVersion),
+                        string(name: 'RAG_VERSION', value: ragVersion),
+                        string(name: 'MA_VERSION', value: multiagentVersion),
+                        string(name: 'GUI_VERSION', value: guiVersion),
                         booleanParam(name: 'debug_mode', value: params.debug_mode),
                     ]
                 }

--- a/ci/pipeline-build-pg.groovy
+++ b/ci/pipeline-build-pg.groovy
@@ -269,8 +269,11 @@ pipeline {
                         string(name: 'deploy_namespace', value: params.deploy_namespace),
                         string(name: 'deploy_type', value: params.deploy_type),
                         string(name: 'BRANCH', value: params.BRANCH),
-                        string(name: 'VERSION', value: params.VERSION),
-                        string(name: 'MODULES_TO_DEPLOY', value: modulesToDeploy),
+                        string(name: 'IDENTITY_VERSION', value: params.VERSION),
+                        string(name: 'BACKEND_VERSION', value: params.VERSION),
+                        string(name: 'RAG_VERSION', value: params.VERSION),
+                        string(name: 'MA_VERSION', value: params.VERSION),
+                        string(name: 'GUI_VERSION', value: params.VERSION),
                         booleanParam(name: 'debug_mode', value: params.debug_mode),
                     ]
                 }

--- a/ci/pipeline-build.groovy
+++ b/ci/pipeline-build.groovy
@@ -268,8 +268,11 @@ pipeline {
                         string(name: 'deploy_location', value: params.deploy_location),
                         string(name: 'deploy_type', value: params.deploy_type),
                         string(name: 'BRANCH', value: params.BRANCH),
-                        string(name: 'VERSION', value: params.VERSION),
-                        string(name: 'MODULES_TO_DEPLOY', value: modulesToDeploy),
+                        string(name: 'IDENTITY_VERSION', value: params.VERSION),
+                        string(name: 'BACKEND_VERSION', value: params.VERSION),
+                        string(name: 'RAG_VERSION', value: params.VERSION),
+                        string(name: 'MA_VERSION', value: params.VERSION),
+                        string(name: 'GUI_VERSION', value: params.VERSION),
                         booleanParam(name: 'debug_mode', value: params.debug_mode),
                     ]
                 }

--- a/ci/pipeline-build.groovy
+++ b/ci/pipeline-build.groovy
@@ -253,26 +253,29 @@ pipeline {
             }
             steps {
                 script {
-                    def modules = []
-                    if (params.build_identity_image) modules << 'identity'
-                    if (params.build_rag_backend) modules << 'rag'
-                    if (params.build_multiagent_backend) modules << 'multiagent'
-                    if (params.build_backend) modules << 'backend'
-                    if (params.build_gui) modules << 'ui'
-                    def modulesToDeploy = modules.join(',')
+                    def identityVersion = ""
+                    def ragVersion = ""
+                    def multiagentVersion = ""
+                    def backendVersion = ""
+                    def guiVersion = ""
+                    if (params.build_identity_image) identityVersion = params.VERSION
+                    if (params.build_rag_backend) ragVersion = params.VERSION
+                    if (params.build_multiagent_backend) multiagentVersion = params.VERSION
+                    if (params.build_backend) backendVersion = params.VERSION
+                    if (params.build_gui) guiVersion = params.VERSION
 
-                    echo "Triggering deployment pipeline with MODULES_TO_DEPLOY = ${modulesToDeploy}"
+                    echo "Triggering deployment pipeline with IDENTITY_VERSION = ${identityVersion}, RAG_VERSION = ${ragVersion}, MULTIAGENT_VERSION = ${multiagentVersion}, BACKEND_VERSION = ${backendVersion}, GUI_VERSION = ${guiVersion}"
                     build job: 'unifai-app-deployer',
                     parameters: [
                         string(name: 'PIPELINE_BRANCH', value: params.PIPELINE_BRANCH),
                         string(name: 'deploy_location', value: params.deploy_location),
                         string(name: 'deploy_type', value: params.deploy_type),
                         string(name: 'BRANCH', value: params.BRANCH),
-                        string(name: 'IDENTITY_VERSION', value: params.VERSION),
-                        string(name: 'BACKEND_VERSION', value: params.VERSION),
-                        string(name: 'RAG_VERSION', value: params.VERSION),
-                        string(name: 'MA_VERSION', value: params.VERSION),
-                        string(name: 'GUI_VERSION', value: params.VERSION),
+                        string(name: 'IDENTITY_VERSION', value: identityVersion),
+                        string(name: 'BACKEND_VERSION', value: backendVersion),
+                        string(name: 'RAG_VERSION', value: ragVersion),
+                        string(name: 'MA_VERSION', value: multiagentVersion),
+                        string(name: 'GUI_VERSION', value: guiVersion),
                         booleanParam(name: 'debug_mode', value: params.debug_mode),
                     ]
                 }

--- a/ci/pipeline-deploy-pg.groovy
+++ b/ci/pipeline-deploy-pg.groovy
@@ -267,7 +267,9 @@ pipeline {
                             echo("Deploy Helm container")
                             sh("podman run --replace -dt --env-file=${vaultEnvFile} --env-file=${configEnvFile} --workdir /helm/charts -v .:/helm/charts:Z -v ~/.kube/:/helm/.kube:Z --name helmfile ghcr.io/helmfile/helmfile:latest bash")                           
                             def modules = buildModulesList()
-                            // the aadding of shared resources stayed here since it saves IF inside the function and then for the deletion of the previous deployment.
+                            if (modules.isEmpty()) {
+                                error("No application modules selected for deployment. Set at least one *_VERSION parameter.")
+                            }
                             if(params.deploy_type == 'FRESH_INSTALL') {
                                 modules.add(0,'shared-resources')
                                 deleteRunningApplication()

--- a/ci/pipeline-deploy-pg.groovy
+++ b/ci/pipeline-deploy-pg.groovy
@@ -7,13 +7,11 @@ properties([
         // 🚀 Deployment Parameters
         choice(name: 'deploy_namespace', choices: ['tag-ai--playground', 'tag-ai--playground2'], description: 'Target OpenShift namespace'),
         choice(name: 'deploy_type', choices: ['FRESH_INSTALL', 'APPLICATION_UPGRADE'], description: 'Deployment type fresh install - delete everything including shared resources, application upgrade - update only the specified modules'),
-        string(name: "VERSION", defaultValue: "", description: "DONT SET THIS VALUE!"),
         string(name: "BACKEND_VERSION", defaultValue: "", description: "Image tag for backend"),
         string(name: "RAG_VERSION", defaultValue: "", description: "Image tag for rag"),
         string(name: "MA_VERSION", defaultValue: "", description: "Image tag for multi-agent"),
         string(name: "GUI_VERSION", defaultValue: "", description: "Image tag for UI"),
         string(name: "IDENTITY_VERSION", defaultValue: "", description: "Image tag for identity"),
-        string(name: "MODULES_TO_DEPLOY", defaultValue: "", description: "Comma-separated list of modules to update (e.g. rag,multiagent,backend,ui,identity)"),
         booleanParam(name: 'debug_mode', defaultValue: false, description: 'debug the pods'),
     ])
 ])
@@ -75,6 +73,17 @@ def generateVaultSecretsEnvFile(String vaultBasePath, Map secretMap) {
     }
     echo "✅ Vault secrets env file created: ${envFilePath}"
     return envFilePath
+}
+
+def buildModulesList() {
+    def versions = (params.IDENTITY_VERSION, params.BACKEND_VERSION, params.RAG_VERSION, params.MA_VERSION, params.GUI_VERSION)
+    def modules = ()
+    versions.each { version ->
+        if(version) {
+            modules.add(version)
+        }
+    }
+    return modules
 }
 
 def updateChartVersions(rootPath, version) {
@@ -254,9 +263,9 @@ pipeline {
                             def vaultEnvFile = generateVaultSecretsEnvFile(buildParams.VaultBasePath, secret_lists)
                             def configEnvFile = "./UnifAI-secrets/staging/.env"
                             echo("Deploy Helm container")
-                            sh("podman run --replace -dt --env-file=${vaultEnvFile} --env-file=${configEnvFile} --workdir /helm/charts -v .:/helm/charts:Z -v ~/.kube/:/helm/.kube:Z --name helmfile ghcr.io/helmfile/helmfile:latest bash")
-                            
-                            def modules = params.MODULES_TO_DEPLOY.tokenize(',')
+                            sh("podman run --replace -dt --env-file=${vaultEnvFile} --env-file=${configEnvFile} --workdir /helm/charts -v .:/helm/charts:Z -v ~/.kube/:/helm/.kube:Z --name helmfile ghcr.io/helmfile/helmfile:latest bash")                           
+                            def modules = buildModulesList()
+                            // the aadding of shared resources stayed here since it saves IF inside the function and then for the deletion of the previous deployment.
                             if(params.deploy_type == 'FRESH_INSTALL') {
                                 modules.add(0,'shared-resources')
                                 deleteRunningApplication()

--- a/ci/pipeline-deploy-pg.groovy
+++ b/ci/pipeline-deploy-pg.groovy
@@ -76,13 +76,12 @@ def generateVaultSecretsEnvFile(String vaultBasePath, Map secretMap) {
 }
 
 def buildModulesList() {
-    def versions = (params.IDENTITY_VERSION, params.BACKEND_VERSION, params.RAG_VERSION, params.MA_VERSION, params.GUI_VERSION)
-    def modules = ()
-    versions.each { version ->
-        if(version) {
-            modules.add(version)
-        }
-    }
+    def modules = []
+    if (params.IDENTITY_VERSION?.trim()) modules.add('identity')
+    if (params.BACKEND_VERSION?.trim()) modules.add('backend')
+    if (params.RAG_VERSION?.trim())     modules.add('rag')
+    if (params.MA_VERSION?.trim())      modules.add('multiagent')
+    if (params.GUI_VERSION?.trim())     modules.add('ui')
     return modules
 }
 
@@ -205,11 +204,14 @@ pipeline {
                 script {
                     echo "================ Deployment Configuration ================="
                     echo "Branch            : ${params.BRANCH}"
-                    echo "Version           : ${params.VERSION}"
                     echo "Deployment Type   : ${params.deploy_type}"
                     echo "Deployment Target : ${params.deploy_namespace}"
                     echo "Debug mode        : ${params.debug_mode}"
-                    echo "Modules to deploy : ${params.MODULES_TO_DEPLOY}"
+                    echo "Identity Version  : ${params.IDENTITY_VERSION}"
+                    echo "Backend Version   : ${params.BACKEND_VERSION}"
+                    echo "RAG Version       : ${params.RAG_VERSION}"
+                    echo "Multiagent Version: ${params.MA_VERSION}"
+                    echo "UI Version        : ${params.GUI_VERSION}"
                     echo "Workspace Path:    ${buildParams.DevRoot}/${params.BRANCH}/"
                     echo "==========================================================="
                 }
@@ -274,40 +276,40 @@ pipeline {
                             for (mod in modules) {
                                 switch(mod.trim()) {
                                     case 'shared-resources':
-                                        updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/shared-resource-values.yaml", version)
+                                        updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/shared-resource-values.yaml", "")
                                         deployModules('shared-resources')
                                         break
 
                                     case 'identity':
-                                        def version = params.IDENTITY_VERSION?.trim() ?: params.VERSION?.trim()
+                                        def version = params.IDENTITY_VERSION?.trim()
                                         updateChartVersions("${buildParams.DevRoot}/${params.BRANCH}/helm/shared-resources/identity/", version)
                                         updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/identity-values.yaml", version)
                                         deployModules('identity')
                                         break
 
                                     case 'backend':
-                                        def version = params.BACKEND_VERSION?.trim() ?: params.VERSION?.trim()
+                                        def version = params.BACKEND_VERSION?.trim()
                                         updateChartVersions("${buildParams.DevRoot}/${params.BRANCH}/helm/backend/", version)
                                         updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/backend-resource-values.yaml", version)
                                         deployModules('backend')
                                         break
 
                                     case 'rag':
-                                        def version = params.RAG_VERSION?.trim() ?: params.VERSION?.trim()
+                                        def version = params.RAG_VERSION?.trim()
                                         updateChartVersions("${buildParams.DevRoot}/${params.BRANCH}/helm/rag/", version)
                                         updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/rag-resource-values.yaml", version)
                                         deployModules('rag')
                                         break
 
                                     case 'multiagent':
-                                        def version = params.MA_VERSION?.trim() ?: params.VERSION?.trim()
+                                        def version = params.MA_VERSION?.trim()
                                         updateChartVersions("${buildParams.DevRoot}/${params.BRANCH}/helm/multiagent/", version)
                                         updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/multiagent-resource-values.yaml", version)
                                         deployModules('multiagent')
                                         break
 
                                     case 'ui':
-                                        def version = params.GUI_VERSION?.trim() ?: params.VERSION?.trim()
+                                        def version = params.GUI_VERSION?.trim()
                                         updateChartVersions("${buildParams.DevRoot}/${params.BRANCH}/helm/ui/", version)
                                         updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/ui-values.yaml", version)
                                         deployModules('ui')

--- a/ci/pipeline-deploy-pg.groovy
+++ b/ci/pipeline-deploy-pg.groovy
@@ -318,10 +318,15 @@ pipeline {
                             }
                             echo("Deploy successfully completed")
                         }
-                        cleanWorkspace()
                     }
                 }
             }
+        }
+    }
+    post {
+        always {
+            sh "rm -f ${buildParams.DevRoot}/${params.BRANCH}/helm/vault_secrets.env"
+            cleanWorkspace()
         }
     }
 

--- a/ci/pipeline-deploy-pg.groovy
+++ b/ci/pipeline-deploy-pg.groovy
@@ -189,7 +189,7 @@ def deleteRunningApplication(){
 
 def cleanWorkspace() {
     sh """
-        podman rm -f helmfile
+        podman rm -f helmfile || true
         sleep 5        
     """
 }

--- a/ci/pipeline-deploy.groovy
+++ b/ci/pipeline-deploy.groovy
@@ -197,7 +197,7 @@ def deleteRunningApplication(){
 
 def cleanWorkspace() {
     sh """
-        podman rm -f helmfile
+        podman rm -f helmfile || true
         sleep 5        
     """
 }

--- a/ci/pipeline-deploy.groovy
+++ b/ci/pipeline-deploy.groovy
@@ -335,10 +335,15 @@ pipeline {
                             }
                             echo("Deploy successfully completed")
                         }
-                        cleanWorkspace()
                     }
                 }
             }
+        }
+    }
+    post {
+        always {
+            sh "rm -f ${buildParams.DevRoot}/${params.BRANCH}/helm/vault_secrets.env"
+            cleanWorkspace()
         }
     }
 

--- a/ci/pipeline-deploy.groovy
+++ b/ci/pipeline-deploy.groovy
@@ -78,13 +78,12 @@ def generateVaultSecretsEnvFile(String vaultBasePath, Map secretMap ) {
 }
 
 def buildModulesList() {
-    def versions = (params.IDENTITY_VERSION, params.BACKEND_VERSION, params.RAG_VERSION, params.MA_VERSION, params.GUI_VERSION)
-    def modules = ()
-    versions.each { version ->
-        if(version) {
-            modules.add(version)
-        }
-    }
+    def modules = []
+    if (params.IDENTITY_VERSION?.trim()) modules.add('identity')
+    if (params.BACKEND_VERSION?.trim()) modules.add('backend')
+    if (params.RAG_VERSION?.trim())     modules.add('rag')
+    if (params.MA_VERSION?.trim())      modules.add('multiagent')
+    if (params.GUI_VERSION?.trim())     modules.add('ui')
     return modules
 }
 
@@ -213,11 +212,14 @@ pipeline {
                 script {
                     echo "================ Deployment Configuration ================="
                     echo "Branch            : ${params.BRANCH}"
-                    echo "Version           : ${params.VERSION}"
                     echo "Deployment Type   : ${params.deploy_type}"
                     echo "Deployment Target : ${params.deploy_location}"
                     echo "Debug mode        : ${params.debug_mode}"
-                    echo "Modules to deploy : ${params.MODULES_TO_DEPLOY}"
+                    echo "Identity Version  : ${params.IDENTITY_VERSION}"
+                    echo "Backend Version   : ${params.BACKEND_VERSION}"
+                    echo "RAG Version       : ${params.RAG_VERSION}"
+                    echo "Multiagent Version: ${params.MA_VERSION}"
+                    echo "UI Version        : ${params.GUI_VERSION}"
                     echo "Workspace Path:    ${buildParams.DevRoot}/${params.BRANCH}/"
                     echo "==========================================================="
                 }
@@ -291,40 +293,40 @@ pipeline {
                             for (mod in modules) {
                                 switch(mod.trim()) {
                                     case 'shared-resources':
-                                        updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/shared-resource-values.yaml", version)
+                                        updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/shared-resource-values.yaml", "")
                                         deployModules('shared-resources')
                                         break
 
                                     case 'identity':
-                                        def version = params.IDENTITY_VERSION?.trim() ?: params.VERSION?.trim()
+                                        def version = params.IDENTITY_VERSION?.trim()
                                         updateChartVersions("${buildParams.DevRoot}/${params.BRANCH}/helm/shared-resources/identity/", version)
                                         updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/identity-values.yaml", version)
                                         deployModules('identity')
                                         break
 
                                     case 'backend':
-                                        def version = params.BACKEND_VERSION?.trim() ?: params.VERSION?.trim()
+                                        def version = params.BACKEND_VERSION?.trim()
                                         updateChartVersions("${buildParams.DevRoot}/${params.BRANCH}/helm/backend/", version)
                                         updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/backend-resource-values.yaml", version)
                                         deployModules('backend')
                                         break
 
                                     case 'rag':
-                                        def version = params.RAG_VERSION?.trim() ?: params.VERSION?.trim()
+                                        def version = params.RAG_VERSION?.trim()
                                         updateChartVersions("${buildParams.DevRoot}/${params.BRANCH}/helm/rag/", version)
                                         updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/rag-resource-values.yaml", version)
                                         deployModules('rag')
                                         break
 
                                     case 'multiagent':
-                                        def version = params.MA_VERSION?.trim() ?: params.VERSION?.trim()
+                                        def version = params.MA_VERSION?.trim()
                                         updateChartVersions("${buildParams.DevRoot}/${params.BRANCH}/helm/multiagent/", version)
                                         updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/multiagent-resource-values.yaml", version)
                                         deployModules('multiagent')
                                         break
 
                                     case 'ui':
-                                        def version = params.GUI_VERSION?.trim() ?: params.VERSION?.trim()
+                                        def version = params.GUI_VERSION?.trim()
                                         updateChartVersions("${buildParams.DevRoot}/${params.BRANCH}/helm/ui/", version)
                                         updateValuesYaml("${buildParams.DevRoot}/${params.BRANCH}/helm/values/ui-values.yaml", version)
                                         deployModules('ui')

--- a/ci/pipeline-deploy.groovy
+++ b/ci/pipeline-deploy.groovy
@@ -284,7 +284,9 @@ pipeline {
                             echo("Deploy Helm container")
                             sh("podman run --replace -dt --env-file=${vaultEnvFile} --env-file=${configEnvFile} --workdir /helm/charts -v .:/helm/charts:Z -v ~/.kube/:/helm/.kube:Z --name helmfile ghcr.io/helmfile/helmfile:latest bash")
                             def modules = buildModulesList()
-                            // the aadding of shared resources stayed here since it saves IF inside the function and then for the deletion of the previous deployment.
+                            if (modules.isEmpty()) {
+                                error("No application modules selected for deployment. Set at least one *_VERSION parameter.")
+                            }
                             if(params.deploy_type == 'FRESH_INSTALL') {
                                 modules.add(0,'shared-resources')
                                 deleteRunningApplication()

--- a/ci/pipeline-deploy.groovy
+++ b/ci/pipeline-deploy.groovy
@@ -7,13 +7,11 @@ properties([
         // 🚀 Deployment Parameters
         choice(name: 'deploy_location', choices: ['STAGING', 'PRODUCTION'], description: 'Deployment environment'),
         choice(name: 'deploy_type', choices: ['FRESH_INSTALL', 'APPLICATION_UPGRADE'], description: 'Deployment Deployment type fresh install - delete everything including shared resources, application upgrade - update only the specified modules'),
-        string(name: "VERSION", defaultValue: "", description: "DONT SET THIS VALUE!"),
         string(name: "BACKEND_VERSION", defaultValue: "", description: "Image tag for backend"),
         string(name: "RAG_VERSION", defaultValue: "", description: "Image tag for rag"),
         string(name: "MA_VERSION", defaultValue: "", description: "Image tag for multi-agent"),
         string(name: "GUI_VERSION", defaultValue: "", description: "Image tag for UI"),
         string(name: "IDENTITY_VERSION", defaultValue: "", description: "Image tag for Identity"),
-        string(name: "MODULES_TO_DEPLOY", defaultValue: "", description: "Comma-separated list of modules to update (e.g. rag,multiagent,backend,ui,identity)"),
         booleanParam(name: 'debug_mode', defaultValue: false, description: 'debug the pods'),
     ])
 ])
@@ -77,6 +75,17 @@ def generateVaultSecretsEnvFile(String vaultBasePath, Map secretMap ) {
     }
     echo "✅ Vault secrets env file created: ${envFilePath}"
     return envFilePath
+}
+
+def buildModulesList() {
+    def versions = (params.IDENTITY_VERSION, params.BACKEND_VERSION, params.RAG_VERSION, params.MA_VERSION, params.GUI_VERSION)
+    def modules = ()
+    versions.each { version ->
+        if(version) {
+            modules.add(version)
+        }
+    }
+    return modules
 }
 
 def updateChartVersions(rootPath, version) {
@@ -272,7 +281,8 @@ pipeline {
                             sh("oc project ${NameSpace}")
                             echo("Deploy Helm container")
                             sh("podman run --replace -dt --env-file=${vaultEnvFile} --env-file=${configEnvFile} --workdir /helm/charts -v .:/helm/charts:Z -v ~/.kube/:/helm/.kube:Z --name helmfile ghcr.io/helmfile/helmfile:latest bash")
-                            def modules = params.MODULES_TO_DEPLOY.tokenize(',')
+                            def modules = buildModulesList()
+                            // the aadding of shared resources stayed here since it saves IF inside the function and then for the deletion of the previous deployment.
                             if(params.deploy_type == 'FRESH_INSTALL') {
                                 modules.add(0,'shared-resources')
                                 deleteRunningApplication()


### PR DESCRIPTION
This PR organizes the dependency ordering of unifai modules.

when adding the enhanced decorators a new dependency was created between the UI and the identity .
the identity should be deployed first and run its post scripts.

in order to overcome this we now will have only one method - sending all versions of all modules (if specific ones aren't built we will send empty string.