### PR TITLE
refactor(slack): rename blueprint to workflow in user-facing commands

### DIFF
--- a/backend/core/app_container.py
+++ b/backend/core/app_container.py
@@ -16,7 +16,7 @@ from slack_commands.commands.delete import DeleteCommand
 from slack_commands.commands.health import HealthCommand
 from slack_commands.commands.help import HelpCommand
 from slack_commands.commands.history import HistoryCommand
-from slack_commands.commands.list_blueprints import ListBlueprintsCommand
+from slack_commands.commands.list_workflows import ListWorkflowsCommand
 from slack_commands.commands.list_sessions import ListSessionsCommand
 from slack_commands.commands.session_status import StatusCommand
 from slack_commands.commands.whoami import WhoamiCommand
@@ -67,7 +67,7 @@ class AppContainer(metaclass=SingletonMeta):
                 "health": HealthCommand(),
                 "whoami": WhoamiCommand(),
                 "list": ListSessionsCommand(base_url=mas_url),
-                "blueprints": ListBlueprintsCommand(base_url=mas_url),
+                "workflows": ListWorkflowsCommand(base_url=mas_url),
                 "ask": AskCommand(base_url=mas_url, executor=session_executor),
                 "status": StatusCommand(base_url=mas_url),
                 "cancel": CancelCommand(base_url=mas_url),

--- a/backend/slack_commands/commands/ask.py
+++ b/backend/slack_commands/commands/ask.py
@@ -1,6 +1,6 @@
-"""Ask command — creates or continues a session against a blueprint.
+"""Ask command — creates or continues a session against a workflow.
 
-Thin handler: parses input, resolves blueprint/session, and delegates
+Thin handler: parses input, resolves workflow/session, and delegates
 the long-running execution to SessionExecutor (deferred response pattern).
 """
 import logging
@@ -56,13 +56,13 @@ class AskCommand(CommandHandler):
                 text=f":hourglass: Continuing session `{ref[:8]}…` with your question...",
             )
 
-        blueprint_id, label = self._resolve_blueprint(command.user_name, ref)
-        if blueprint_id is None:
+        workflow_id, label = self._resolve_workflow(command.user_name, ref)
+        if workflow_id is None:
             return label
 
         self._executor.run_new_session(
             user_name=command.user_name,
-            blueprint_id=blueprint_id,
+            workflow_id=workflow_id,
             question=question,
             response_url=command.response_url,
             public=command.public,
@@ -93,8 +93,8 @@ class AskCommand(CommandHandler):
             logger.warning("session_exists check failed: %s", e)
             return None
 
-    def _resolve_blueprint(self, user_name: str, ref: str):
-        """Resolve a blueprint reference (UUID or name) to (id, display_label).
+    def _resolve_workflow(self, user_name: str, ref: str):
+        """Resolve a workflow reference (UUID or name) to (id, display_label).
 
         Returns (None, SlackResponse) on error so the caller can short-circuit.
         """
@@ -111,12 +111,12 @@ class AskCommand(CommandHandler):
             resp.raise_for_status()
         except requests.RequestException as e:
             raise MASRequestError(
-                handle_client_error(e, operation="Blueprint lookup"),
+                handle_client_error(e, operation="Workflow lookup"),
             ) from e
-        blueprints = resp.json()
+        workflows = resp.json()
 
         matches = [
-            bp for bp in blueprints
+            bp for bp in workflows
             if (bp.get("name") or bp.get("spec_dict", {}).get("name") or "").lower() == ref.lower()
         ]
 
@@ -133,15 +133,15 @@ class AskCommand(CommandHandler):
             )
             return None, SlackResponse(
                 text=(
-                    f":warning: Multiple blueprints named *{ref}*:\n{ids}\n"
+                    f":warning: Multiple workflows named *{ref}*:\n{ids}\n"
                     f"Please use the full ID."
                 ),
             )
 
         return None, SlackResponse(
             text=(
-                f":x: No blueprint found with name *{ref}*.\n"
-                f"Run `/unifai blueprints` to see available options."
+                f":x: No workflow found with name *{ref}*.\n"
+                f"Run `/unifai workflows` to see available options."
             ),
         )
 
@@ -150,8 +150,8 @@ class AskCommand(CommandHandler):
         return SlackResponse(
             text=(
                 "*Usage:*\n"
-                "• `/unifai ask <blueprint> <question>` — Start a new session\n"
+                "• `/unifai ask <workflow> <question>` — Start a new session\n"
                 "• `/unifai ask <session_id> <question>` — Continue an existing session\n"
-                "\nRun `/unifai blueprints` to see available blueprints."
+                "\nRun `/unifai workflows` to see available workflows."
             ),
         )

--- a/backend/slack_commands/commands/help.py
+++ b/backend/slack_commands/commands/help.py
@@ -10,7 +10,7 @@ class HelpCommand(CommandHandler):
             text=(
                 "*Available Commands*\n\n"
                 "*Sessions*\n"
-                "• `/unifai ask <blueprint> <question>` — Start a new session\n"
+                "• `/unifai ask <workflow> <question>` — Start a new session\n"
                 "• `/unifai ask <session_id> <question>` — Continue an existing session\n"
                 "• `/unifai list [page]` — List your sessions\n"
                 "• `/unifai status <session_id>` — Check session status\n"
@@ -18,7 +18,7 @@ class HelpCommand(CommandHandler):
                 "• `/unifai cancel <session_id>` — Cancel a running session\n"
                 "• `/unifai delete <session_id>` — Permanently delete a session\n\n"
                 "*Discovery*\n"
-                "• `/unifai blueprints` — List available blueprints\n\n"
+                "• `/unifai workflows` — List available workflows\n\n"
                 "*Utility*\n"
                 "• `/unifai help` — Show this message\n"
                 "• `/unifai health` — Check service status\n"

--- a/backend/slack_commands/commands/list_workflows.py
+++ b/backend/slack_commands/commands/list_workflows.py
@@ -1,13 +1,13 @@
-"""List blueprints command — shows available blueprints from multi-agent."""
+"""List workflows command — shows available workflows from multi-agent."""
 import requests
 
 from slack_commands.commands.base import CommandHandler
 from slack_commands.http import MAS_TIMEOUT, handle_client_error, mas_get
-from slack_commands.formatters import format_blueprint_list
+from slack_commands.formatters import format_workflow_list
 from slack_commands.models import MASRequestError, SlackCommand, SlackResponse
 
 
-class ListBlueprintsCommand(CommandHandler):
+class ListWorkflowsCommand(CommandHandler):
 
     def __init__(self, base_url: str):
         self._url = base_url.rstrip("/")
@@ -21,10 +21,10 @@ class ListBlueprintsCommand(CommandHandler):
                 timeout=MAS_TIMEOUT,
             )
             resp.raise_for_status()
-            blueprints = resp.json()
+            workflows = resp.json()
         except requests.RequestException as e:
             raise MASRequestError(
-                handle_client_error(e, operation="Blueprint listing"),
+                handle_client_error(e, operation="Workflow listing"),
             ) from e
 
-        return format_blueprint_list(blueprints)
+        return format_workflow_list(workflows)

--- a/backend/slack_commands/execution/session_executor.py
+++ b/backend/slack_commands/execution/session_executor.py
@@ -37,7 +37,7 @@ class SessionExecutor:
     def run_new_session(
         self,
         user_name: str,
-        blueprint_id: str,
+        workflow_id: str,
         question: str,
         response_url: str,
         *,
@@ -45,7 +45,7 @@ class SessionExecutor:
     ) -> None:
         """Submit a background task that creates, submits, polls, and responds."""
         self._pool.submit(
-            self._execute, user_name, blueprint_id, question, response_url, False, public,
+            self._execute, user_name, workflow_id, question, response_url, False, public,
         )
 
     def continue_session(
@@ -123,12 +123,12 @@ class SessionExecutor:
 
     # ── MAS API calls ─────────────────────────────────────────────
 
-    def _create_session(self, user_name: str, blueprint_id: str) -> str:
+    def _create_session(self, user_name: str, workflow_id: str) -> str:
         resp = mas_post(
             f"{self._url}/api/sessions/user.session.create",
             user_name,
             {
-                "blueprintId": blueprint_id,
+                "blueprintId": workflow_id,
                 "userId": user_name,
                 "identityType": "user",
             },

--- a/backend/slack_commands/formatters.py
+++ b/backend/slack_commands/formatters.py
@@ -63,22 +63,22 @@ def format_session_list(
     return SlackResponse(text="\n".join(lines))
 
 
-def format_blueprint_list(blueprints: list) -> SlackResponse:
-    """Format a list of blueprint dicts into a Slack message."""
-    if not blueprints:
-        return SlackResponse(text=":inbox_tray: No blueprints available.")
+def format_workflow_list(workflows: list) -> SlackResponse:
+    """Format a list of workflow dicts into a Slack message."""
+    if not workflows:
+        return SlackResponse(text=":inbox_tray: No workflows available.")
 
-    lines = [f"*Available Blueprints* ({len(blueprints)} total)\n"]
+    lines = [f"*Available Workflows* ({len(workflows)} total)\n"]
 
-    for bp in blueprints[:15]:
-        bp_id = bp.get("blueprint_id", "?")
-        name = bp.get("name") or bp.get("spec_dict", {}).get("name") or bp_id
-        description = bp.get("description") or ""
+    for wf in workflows[:15]:
+        wf_id = wf.get("blueprint_id", "?")
+        name = wf.get("name") or wf.get("spec_dict", {}).get("name") or wf_id
+        description = wf.get("description") or ""
 
         desc_suffix = f" — _{description}_" if description else ""
-        lines.append(f":blue_book: `{bp_id}` — *{name}*{desc_suffix}")
+        lines.append(f":blue_book: `{wf_id}` — *{name}*{desc_suffix}")
 
-    if len(blueprints) > 15:
-        lines.append(f"\n_…and {len(blueprints) - 15} more_")
+    if len(workflows) > 15:
+        lines.append(f"\n_…and {len(workflows) - 15} more_")
 
     return SlackResponse(text="\n".join(lines))


### PR DESCRIPTION
Rename the Slack command terminology from "blueprint" to "workflow" across all user-facing text, command names, and internal variables. MAS API endpoints and payload keys remain unchanged.

- Rename list_blueprints.py → list_workflows.py
- /unifai blueprints → /unifai workflows
- ask <blueprint> → ask <workflow>
- Update formatters, session executor, and app container wiring