### PR TITLE
fix(slack): allow UUID to resolve as workflow ID when not a session

### DIFF
--- a/backend/slack_commands/commands/ask.py
+++ b/backend/slack_commands/commands/ask.py
@@ -41,20 +41,18 @@ class AskCommand(CommandHandler):
                 return SlackResponse(
                     text=":x: Could not verify session. Please try again.",
                 )
-            if not exists:
-                return SlackResponse(
-                    text=f":x: Session `{ref}` not found.",
+            if exists:
+                self._executor.continue_session(
+                    user_name=command.user_name,
+                    session_id=ref,
+                    question=question,
+                    response_url=command.response_url,
+                    public=command.public,
                 )
-            self._executor.continue_session(
-                user_name=command.user_name,
-                session_id=ref,
-                question=question,
-                response_url=command.response_url,
-                public=command.public,
-            )
-            return SlackResponse(
-                text=f":hourglass: Continuing session `{ref[:8]}…` with your question...",
-            )
+                return SlackResponse(
+                    text=f":hourglass: Continuing session `{ref[:8]}…` with your question...",
+                )
+            # UUID is not a session — treat it as a workflow ID below
 
         workflow_id, label = self._resolve_workflow(command.user_name, ref)
         if workflow_id is None:

--- a/backend/slack_commands/commands/ask.py
+++ b/backend/slack_commands/commands/ask.py
@@ -36,12 +36,7 @@ class AskCommand(CommandHandler):
         ref, question = sanitize_slack_arg(parts[0]), parts[1]
 
         if _UUID_PATTERN.match(ref):
-            exists = self._session_exists(ref, command.user_name)
-            if exists is None:
-                return SlackResponse(
-                    text=":x: Could not verify session. Please try again.",
-                )
-            if exists:
+            if self._session_exists(ref, command.user_name):
                 self._executor.continue_session(
                     user_name=command.user_name,
                     session_id=ref,
@@ -52,7 +47,7 @@ class AskCommand(CommandHandler):
                 return SlackResponse(
                     text=f":hourglass: Continuing session `{ref[:8]}…` with your question...",
                 )
-            # UUID is not a session — treat it as a workflow ID below
+            # UUID is not a confirmed session — treat it as a workflow ID below
 
         workflow_id, label = self._resolve_workflow(command.user_name, ref)
         if workflow_id is None:

--- a/backend/slack_commands/commands/session_status.py
+++ b/backend/slack_commands/commands/session_status.py
@@ -29,6 +29,8 @@ class StatusCommand(CommandHandler):
             )
             status_resp.raise_for_status()
             status = status_resp.json()
+            if isinstance(status, dict):
+                status = status.get("status")
             status = status.upper() if isinstance(status, str) else None
 
             meta_resp = mas_get(

--- a/backend/slack_commands/http.py
+++ b/backend/slack_commands/http.py
@@ -3,17 +3,13 @@ import logging
 
 import requests
 
-from slack_commands.models import MASRequestError, SlackResponse
+from slack_commands.models import SlackResponse
 
 logger = logging.getLogger(__name__)
 
 _AUTH_HEADER = "X-Authenticated-User"
 
 MAS_TIMEOUT = 10
-
-
-def auth_headers(user_id: str) -> dict:
-    return {_AUTH_HEADER: user_id}
 
 
 def mas_get(


### PR DESCRIPTION
When a UUID doesn't match an existing session, fall through to _resolve_workflow instead of returning "Session not found". This lets users start new sessions with a workflow UUID directly.