### PR TITLE
fix(identity): preserve team names in Redis cache to fix analytics di…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@ backend/ @sfiresht @yhabushi79 @odaiodeh @nirsisr @Lina-AbuYousef @MayaCrmi
 rag/ @odaiodeh @nirsisr @Lina-AbuYousef
 ui/ @nirsisr @Lina-AbuYousef @MayaCrmi
 shared-resources/ @yhabushi79 @nirsisr @sfiresht
-multi-agent/ @odaiodeh @nirsisr @Lina-AbuYousef
+multi-agent/ @odaiodeh @nirsisr @Lina-AbuYousef @shanitzvii 
 
 # CI/CD & Testing locations
 ci/ @sfiresht @yhabushi79 @MayaCrmi @shanitzvii 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@ backend/ @sfiresht @yhabushi79 @odaiodeh @nirsisr @Lina-AbuYousef @MayaCrmi
 rag/ @odaiodeh @nirsisr @Lina-AbuYousef
 ui/ @nirsisr @Lina-AbuYousef @MayaCrmi
 shared-resources/ @yhabushi79 @nirsisr @sfiresht
-multi-agent/ @odaiodeh @nirsisr @Lina-AbuYousef @shanitzvii 
+multi-agent/ @odaiodeh @nirsisr @Lina-AbuYousef
 
 # CI/CD & Testing locations
 ci/ @sfiresht @yhabushi79 @MayaCrmi @shanitzvii 

--- a/global_utils/src/global_utils/identity_client.py
+++ b/global_utils/src/global_utils/identity_client.py
@@ -55,10 +55,7 @@ class IdentityClient:
 
     def _get_cached_teams(self, username: str) -> Optional[list[dict]]:
         if self._team_cache is not None:
-            ids = self._team_cache.get_team_ids(username)
-            if ids is not None:
-                return [{"team_id": tid} for tid in ids]
-            return None
+            return self._team_cache.get_teams(username)
         now = time.monotonic()
         with self._cache_lock:
             entry = self._mem_cache.get(username)
@@ -68,8 +65,11 @@ class IdentityClient:
 
     def _set_cached_teams(self, username: str, teams: list[dict]) -> None:
         if self._team_cache is not None:
-            ids = [str(t.get("team_id")) for t in teams if t.get("team_id") is not None]
-            self._team_cache.set_team_ids(username, ids)
+            entries = [
+                {"team_id": str(t["team_id"]), "name": t.get("name", "")}
+                for t in teams if t.get("team_id") is not None
+            ]
+            self._team_cache.set_teams(username, entries)
             return
         with self._cache_lock:
             self._mem_cache[username] = (time.monotonic(), teams)

--- a/global_utils/src/global_utils/redis/team_cache.py
+++ b/global_utils/src/global_utils/redis/team_cache.py
@@ -7,7 +7,7 @@ a per-user key with a TTL), but lives in ``global_utils`` so any Flask
 service can leverage it via ``IdentityClient``.
 
 Keys: ``identity:user_teams:{username}``
-Value: JSON-encoded ``list[str]`` of team IDs.
+Value: JSON-encoded ``list[dict]`` of team objects (``team_id`` + ``name``).
 """
 import json
 import logging
@@ -23,14 +23,14 @@ KEY_PREFIX = f"{IDENTITY_USER_TEAMS_PREFIX}:"
 
 
 class TeamMembershipCache:
-    """Thin Redis wrapper for user -> team-ID lists."""
+    """Thin Redis wrapper for user -> team lists (ID + name)."""
 
     def __init__(self, store: RedisKVStore, ttl: int = _DEFAULT_TTL):
         self._store = store
         self._ttl = ttl
 
-    def get_team_ids(self, username: str) -> Optional[List[str]]:
-        """Return cached team IDs or ``None`` on a miss / error."""
+    def get_teams(self, username: str) -> Optional[List[dict]]:
+        """Return cached team objects or ``None`` on a miss / error."""
         try:
             raw = self._store.get(self._key(username))
             if raw is None:
@@ -40,11 +40,11 @@ class TeamMembershipCache:
             logger.exception("Failed to read team cache for %s", username)
             return None
 
-    def set_team_ids(self, username: str, team_ids: List[str]) -> None:
-        """Write team IDs with TTL."""
+    def set_teams(self, username: str, teams: List[dict]) -> None:
+        """Write team objects (team_id + name) with TTL."""
         try:
-            self._store.set(self._key(username), json.dumps(team_ids), ttl_seconds=self._ttl)
-            logger.debug("Cached %d teams for %s (ttl=%ds)", len(team_ids), username, self._ttl)
+            self._store.set(self._key(username), json.dumps(teams), ttl_seconds=self._ttl)
+            logger.debug("Cached %d teams for %s (ttl=%ds)", len(teams), username, self._ttl)
         except Exception:
             logger.exception("Failed to cache teams for %s", username)
 

--- a/scripts/migrate_team_display_names.js
+++ b/scripts/migrate_team_display_names.js
@@ -1,0 +1,87 @@
+/**
+ * Migration: Fix team display_name in workflow_sessions.
+ *
+ * Finds all team sessions where display_name is stored as the team UUID
+ * (instead of the human-readable name) and patches them using the team
+ * name from the Identity database.
+ *
+ * Usage (local via podman):
+ *   podman cp scripts/migrate_team_display_names.js <mongo_container>:/tmp/migrate_team_display_names.js
+ *   podman exec <mongo_container> mongosh --eval "var DRY_RUN=true" /tmp/migrate_team_display_names.js
+ *   podman exec <mongo_container> mongosh --eval "var DRY_RUN=false" /tmp/migrate_team_display_names.js
+ *
+ * Usage (OpenShift via oc):
+ *   oc cp scripts/migrate_team_display_names.js <mongo_pod>:/tmp/migrate_team_display_names.js
+ *   oc exec <mongo_pod> -- mongosh --eval "var DRY_RUN=true" /tmp/migrate_team_display_names.js
+ *   oc exec <mongo_pod> -- mongosh --eval "var DRY_RUN=false" /tmp/migrate_team_display_names.js
+ *
+ * DRY_RUN=true  → only prints what WOULD be fixed (no writes)
+ * DRY_RUN=false → actually patches the records
+ *
+ * Safe to run multiple times (idempotent).
+ */
+
+const dryRun = (typeof DRY_RUN !== "undefined") ? DRY_RUN : true;
+
+print(dryRun ? "=== DRY RUN (no changes will be made) ===" : "=== LIVE RUN (will modify records) ===");
+print("");
+
+const sessionsDb = db.getSiblingDB("UnifAI");
+const identityDb = db.getSiblingDB("users");
+
+// Step 1: Build team_id → name lookup from Identity DB
+const allTeams = identityDb.teams.find({}, { team_id: 1, name: 1, _id: 0 }).toArray();
+const teamMap = {};
+allTeams.forEach(t => { teamMap[t.team_id] = t.name; });
+
+print(`Loaded ${allTeams.length} teams from Identity DB`);
+
+// Step 2: Find all team sessions where display_name == team_id (broken records)
+const broken = sessionsDb.workflow_sessions.aggregate([
+    { $match: { "identity.type": "team", $expr: { $eq: ["$identity.display_name", "$identity.id"] } } },
+    { $group: { _id: "$identity.id", count: { $sum: 1 } } }
+]).toArray();
+
+if (broken.length === 0) {
+    print("\nNo broken records found. Nothing to do.");
+    quit();
+}
+
+print(`\nFound ${broken.length} team(s) with UUID as display_name:\n`);
+
+let totalFixed = 0;
+let totalSkipped = 0;
+
+// Step 3: For each broken team, look up real name and patch
+broken.forEach(entry => {
+    const teamId = entry._id;
+    const count = entry.count;
+    const realName = teamMap[teamId];
+
+    if (!realName) {
+        print(`  SKIP: ${teamId} (${count} sessions) — team not found in Identity DB`);
+        totalSkipped += count;
+        return;
+    }
+
+    if (dryRun) {
+        print(`  WOULD FIX: ${teamId} → "${realName}" (${count} sessions)`);
+        totalFixed += count;
+    } else {
+        const result = sessionsDb.workflow_sessions.updateMany(
+            {
+                "identity.type": "team",
+                "identity.id": teamId,
+                "identity.display_name": teamId
+            },
+            { $set: { "identity.display_name": realName } }
+        );
+        print(`  FIXED: ${teamId} → "${realName}" (${result.modifiedCount} sessions updated)`);
+        totalFixed += result.modifiedCount;
+    }
+});
+
+print(`\nDone. ${dryRun ? "Would fix" : "Fixed"}: ${totalFixed}, Skipped: ${totalSkipped}`);
+if (dryRun) {
+    print("\nTo apply changes, re-run with DRY_RUN=false");
+}


### PR DESCRIPTION
## Root cause

When a team workflow runs, the system needs the team name. It asks Redis for it, but Redis only stored team IDs — not names. So it returned the UUID as the name, and that UUID got saved permanently in MongoDB.

**Before (broken):**

```json
["1252c5bd...", "03f76cd6...", "af6b942d..."]
```

**After (fixed):**

```json
[
  {"team_id": "1252c5bd...", "name": "123"},
  {"team_id": "03f76cd6...", "name": "ccxas"},
  {"team_id": "af6b942d...", "name": "test-team"}
]
```

## The fix

Changed Redis to store team names alongside IDs. Now when the system asks "what's this team's name?", Redis has the answer.

**Files changed:**

- `global_utils/src/global_utils/redis/team_cache.py` — store/read `[{team_id, name}]` instead of `[id]`
- `global_utils/src/global_utils/identity_client.py` — preserve team name when writing to cache

## The migration script

Old sessions in MongoDB already have the UUID saved as the team name. The script finds those records, looks up the real name from the Identity database, and patches them.
