### PR TITLE
Monitoring | Cost | GUI integration with Langfuse

### DIFF
--- a/multi-agent/adapters/outbound/langfuse/langfuse_tracing_service.py
+++ b/multi-agent/adapters/outbound/langfuse/langfuse_tracing_service.py
@@ -181,3 +181,14 @@ class LangfuseTracingService(TracingService):
 
     def flush(self) -> None:
         self._client.flush()
+
+    # ── cost lookup ──────────────────────────────────────────────
+
+    def get_session_cost(self, session_id: str) -> Optional[float]:
+        trace_id = self._client.create_trace_id(seed=session_id)
+        try:
+            trace = self._client.api.trace.get(trace_id, fields="core,metrics")
+            return float(trace.total_cost or 0)
+        except Exception:
+            logger.debug("Trace for session %s not found in Langfuse", session_id)
+            return None

--- a/multi-agent/bootstrap/container.py
+++ b/multi-agent/bootstrap/container.py
@@ -306,6 +306,7 @@ class AppContainer(metaclass=SingletonMeta):
             foreground_runner=foreground_runner,
             input_projector=self.input_projector,
             background_engine=background_engine,
+            tracing_service=self.tracing_service,
         )
 
         self.redis_kv_store = RedisKVStore(build_redis_client())

--- a/multi-agent/lib/mas/core/tracing/service.py
+++ b/multi-agent/lib/mas/core/tracing/service.py
@@ -65,3 +65,12 @@ class TracingService(ABC):
 
     @abstractmethod
     def flush(self) -> None: ...
+
+    def get_session_cost(self, session_id: str) -> Optional[float]:
+        """Fetch the total USD cost for a session from the tracing backend.
+
+        Returns a float (>= 0) when the session exists in the tracing
+        backend, or None when it does not.  Non-abstract so existing
+        subclasses aren't forced to implement it.
+        """
+        return None

--- a/multi-agent/lib/mas/session/service.py
+++ b/multi-agent/lib/mas/session/service.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 from datetime import datetime
+from mas.core.tracing import TracingService
 from mas.session.management.user_session_manager import UserSessionManager
 from mas.session.execution.foreground_runner import ForegroundSessionRunner
 from mas.session.execution.input_projector import SessionInputProjector
@@ -39,11 +40,13 @@ class SessionService:
         foreground_runner: ForegroundSessionRunner,
         input_projector: SessionInputProjector,
         background_engine: Optional[BackgroundSessionEngine] = None,
+        tracing_service: Optional[TracingService] = None,
     ):
         self._manager = manager
         self._foreground = foreground_runner
         self._projector = input_projector
         self._engine = background_engine
+        self._tracing = tracing_service
 
     def create(
         self,
@@ -362,11 +365,17 @@ class SessionService:
     def list_user_sessions(self, identity: Identity) -> list:
         """
         List all sessions created by a user (metadata only, no messages).
+
+        For terminal sessions that have been traced but whose cost hasn't
+        been persisted yet, fetches the cost from the tracing backend and
+        caches it in Mongo so subsequent calls don't need the API.
         """
         docs = self._manager.list_docs(identity)
         items = []
 
         for doc in docs:
+            self._backfill_cost(doc)
+
             blueprint_id = doc.get("blueprint_id", "")
             blueprint_exists = self._manager.blueprint_exists(blueprint_id) if blueprint_id else False
             bp_metadata = self._manager.get_blueprint_metadata(blueprint_id) if blueprint_exists else {}
@@ -381,6 +390,40 @@ class SessionService:
             items.append(item.model_dump())
 
         return items
+
+    def _backfill_cost(self, doc: Dict[str, Any]) -> None:
+        """Fetch session cost from the tracing backend and cache in Mongo.
+
+        Stores ``cost_updated_at`` alongside ``total_cost`` so we can
+        detect staleness: when ``last_active_at`` is newer than the
+        stored timestamp, the session had new activity and the cost is
+        re-fetched.  Sessions not found in Langfuse get ``total_cost: None``
+        to avoid repeated lookups.
+        """
+        if self._tracing is None or not self._tracing.enabled:
+            return
+        status = doc.get("status", "")
+        if status not in ({"COMPLETED", "FAILED"}):
+            return
+        meta = doc.get("metadata", {})
+        last_active = doc.get("run_context", {}).get("last_active_at", "")
+        cost_updated = meta.get("cost_updated_at", "")
+        if "total_cost" in meta and (not last_active or cost_updated >= last_active):
+            return
+        session_id = doc.get("run_id", "")
+        if not session_id:
+            return
+        try:
+            cost = self._tracing.get_session_cost(session_id)
+            meta["total_cost"] = cost
+            meta["cost_updated_at"] = last_active or datetime.utcnow().isoformat()
+            doc["metadata"] = meta
+            record = self._manager.get_record(session_id)
+            record.metadata.total_cost = cost
+            record.metadata.cost_updated_at = meta["cost_updated_at"]
+            self._manager.save_record(record)
+        except Exception:
+            logger.debug("Cost backfill failed for session %s", session_id, exc_info=True)
 
     def get_user_blueprints(self, identity: Identity) -> List[str]:
         """

--- a/multi-agent/scripts/backfill_session_cost.py
+++ b/multi-agent/scripts/backfill_session_cost.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+One-time migration: stamp every session in workflow_sessions with
+total_cost=None and cost_updated_at="2026-07-31T00:00:00" so that
+the lazy backfill in SessionService._backfill_cost only queries
+Langfuse for sessions whose last_active_at is after that date.
+
+Usage:
+    # Dry run (default) — reports what would be updated
+    python backfill_session_cost.py
+
+    # Apply changes
+    python backfill_session_cost.py --apply
+
+    # Custom connection
+    python backfill_session_cost.py --host 10.0.0.5 --port 27017 --db MyDB
+"""
+import argparse
+from pymongo import MongoClient
+
+COST_TRACKING_START = "2026-07-31T00:00:00"
+COLLECTION = "workflow_sessions"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Backfill session cost fields")
+    parser.add_argument("--apply", action="store_true", help="Apply changes (default is dry-run)")
+    parser.add_argument("--host", default="localhost")
+    parser.add_argument("--port", default="27017")
+    parser.add_argument("--db", default="UnifAI")
+    parser.add_argument("--collection", default=COLLECTION)
+    args = parser.parse_args()
+
+    client = MongoClient(f"mongodb://{args.host}:{args.port}/")
+    col = client[args.db][args.collection]
+
+    total = col.count_documents({})
+    already_stamped = col.count_documents({"metadata.cost_updated_at": {"$exists": True}})
+    to_update = col.count_documents({"metadata.cost_updated_at": {"$exists": False}})
+
+    print(f"Database:        {args.db}")
+    print(f"Collection:      {args.collection}")
+    print(f"Total sessions:  {total}")
+    print(f"Already stamped: {already_stamped}")
+    print(f"To update:       {to_update}")
+    print(f"Stamp value:     cost_updated_at={COST_TRACKING_START}, total_cost=None")
+    print()
+
+    if to_update == 0:
+        print("Nothing to do.")
+        return
+
+    if not args.apply:
+        print("DRY RUN — no changes made. Pass --apply to execute.")
+        return
+
+    result = col.update_many(
+        {"metadata.cost_updated_at": {"$exists": False}},
+        {"$set": {
+            "metadata.total_cost": None,
+            "metadata.cost_updated_at": COST_TRACKING_START,
+        }},
+    )
+    print(f"Updated {result.modified_count} sessions.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ui/client/src/components/agentic-ai/ExecutionTab.tsx
+++ b/ui/client/src/components/agentic-ai/ExecutionTab.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { motion } from "framer-motion";
-import { MessageSquare, Users, Clock, Trash2, Plus } from "lucide-react";
+import { MessageSquare, Users, Clock, Trash2, Plus, DollarSign } from "lucide-react";
 import ChatInterface from "./chat/ChatInterface";
 import ExecutionStream from "./ExecutionStream";
 import GraphDisplay from "./graphs/GraphDisplay";
@@ -307,6 +307,16 @@ export default function ExecutionTab({ runId, onSessionChange }: ExecutionTabPro
                       <div className="mt-1 flex items-center text-xs text-gray-400">
                         <Clock className="h-3 w-3 mr-1" />
                         <span>{session.lastActive}</span>
+                        {session.totalCost != null && session.totalCost > 0 && (
+                          <span
+                            className="inline-flex items-center ml-1.5"
+                            title={"Cost tracking started on July 31, 2026.\nClaude Agent Nodes & Deep Agents costs are not yet included in the session total."}
+                          >
+                            <span className="text-gray-600 mr-1.5">·</span>
+                            <DollarSign className="h-3 w-3 mr-0.5 text-emerald-500" />
+                            <span className="text-emerald-400">{session.totalCost.toFixed(4)}</span>
+                          </span>
+                        )}
                       </div>
                       <p className="mt-1 text-xs text-gray-500 truncate">
                         {session.preview}

--- a/ui/client/src/types/session.ts
+++ b/ui/client/src/types/session.ts
@@ -22,6 +22,7 @@ export interface ChatSession {
   hitlEnabled?: boolean;
   status?: string;
   statusMessage?: string;
+  totalCost?: number | null;
 }
 
 // Types for the API response

--- a/ui/client/src/utils/sessionHelpers.ts
+++ b/ui/client/src/utils/sessionHelpers.ts
@@ -52,6 +52,8 @@ export const transformSessionData = (
   const timestamp = new Date(activityTimestamp);
   const lastActive = formatRelativeTimestamp(activityTimestamp);
   const preview = fromSharedLink ? 'From chat experience' : 'Click to load messages...';
+  const rawCost = sessionData.metadata?.total_cost;
+  const totalCost = typeof rawCost === 'number' ? rawCost : null;
 
   return {
     id,
@@ -60,12 +62,13 @@ export const transformSessionData = (
     lastActive,
     timestamp,
     preview,
-    messages: [], // Messages will be loaded separately when session is selected
+    messages: [],
     blueprintExists,
     fromSharedLink,
     hitlEnabled,
     fromSchedule,
     status,
+    totalCost,
   };
 };
 


### PR DESCRIPTION
## Summary

  Integrates Langfuse session cost data into the UnifAI platform — fetching, caching, and displaying the total LLM cost per session.

  ### What it does

  - **Lazy cost backfill**: When `session.user.list` is called, each completed/failed session's cost is fetched from Langfuse (once) and cached in MongoDB (`metadata.total_cost` + `metadata.cost_updated_at`).
  Subsequent list calls serve the cached value — zero Langfuse API overhead.
  - **Staleness detection**: If a user sends additional questions to a session, `last_active_at` advances past `cost_updated_at`, triggering a re-fetch on the next list call so the cost stays accurate.
  - **Single API call per fetch**: Uses `create_trace_id(seed=session_id)` to deterministically derive the Langfuse trace ID, then calls `client.api.trace.get(trace_id, fields="core,metrics")` — one HTTP request
  returns the pre-aggregated `total_cost`.
  - **Migration script**: `backfill_session_cost.py` stamps all existing sessions with `total_cost: None` and `cost_updated_at: "2026-07-31T00:00:00"` (the date Langfuse was introduced), preventing API overload on
  historical sessions that predate tracing.
  - **UI display**: Green `$` icon with cost (4 decimal places) next to the session timestamp in the sidebar. Hover tooltip explains tracking limitations (start date and untracked node types).

  ### How the mechanism works

  1. **Migration (one-time)**: Run `backfill_session_cost.py --apply` to stamp all existing sessions. Old sessions get `cost_updated_at = July 31 2026`, which is >= their `last_active_at`, so they're permanently
  skipped.
  2. **On `session.user.list`**: For each terminal session (`COMPLETED`/`FAILED`):
     - If `total_cost` exists AND `cost_updated_at >= last_active_at` → use cached value (no API call)
     - Otherwise → fetch from Langfuse, persist both `total_cost` and `cost_updated_at`, update the in-memory doc
  3. **On session re-use**: User sends new question → session runs again → `last_active_at` updates → next list call detects staleness → re-fetches cost

  ### Files changed

  | Layer | File | Change |
  |---|---|---|
  | Domain port | `multi-agent/lib/mas/core/tracing/service.py` | Added `get_session_cost()` with default `return None` |
  | Langfuse adapter | `multi-agent/adapters/outbound/langfuse/langfuse_tracing_service.py` | Implemented single-call cost lookup via trace API |
  | Application service | `multi-agent/lib/mas/session/service.py` | Added `_backfill_cost()` with staleness logic in `list_user_sessions()` |
  | Composition root | `multi-agent/bootstrap/container.py` | Wired `tracing_service` into `SessionService` |
  | Migration script | `multi-agent/run/scripts/backfill_session_cost.py` | One-time DB stamp (supports `--apply` / dry-run) |
  | UI type | `ui/client/src/types/session.ts` | Added `totalCost?: number \| null` |
  | UI transform | `ui/client/src/utils/sessionHelpers.ts` | Extract `total_cost` from API metadata |
  | UI display | `ui/client/src/components/agentic-ai/ExecutionTab.tsx` | Cost icon + hover tooltip |
  
  
**Nir Additional Note:**
 We can't trigger Langfuse APIs once any SESSION COMPLETE, since the data not persistence in langFuse immediately. Also we can't trigger 10-30 seconds after SESSION change to complete status since the Temporal process who ran the session is OFF, not exist. Therefore we track the COSTS only when the SESSIONS API called and add it to Metadata (when it happened) so we will never repeat APIs twice.

To make it SOLID (with the best design and coding):
We need to have an HOOK from langFuse that HIT a new API on our end, the HOOK hits when session where already added to Langfuse, data is persistent, than we can collect the COST and add to the DB directly, no need to call COSTS APIs later. That will require more work from our side.