### PR TITLE
security: stop exposing Keycloak access token to frontend clients

### DIFF
--- a/shared-resources/identity/adapters/inbound/flask/endpoints/directory_routes.py
+++ b/shared-resources/identity/adapters/inbound/flask/endpoints/directory_routes.py
@@ -18,7 +18,13 @@ def _parse_limit(default: int = 20) -> int:
 
 
 def _user_token():
-    return request.headers.get("X-User-Token")
+    """Retrieve the user's access token from the server-side session."""
+    auth_manager = current_app.extensions.get('auth_manager')
+    if auth_manager:
+        session_data = auth_manager._get_server_session()
+        if session_data:
+            return session_data.get('access_token')
+    return request.headers.get("X-User-Token")  # ponytail: fallback for backward compat
 
 
 def _cached_fetch(cache, cache_key: str, fetch: Callable, response_key: str, log_action: str):

--- a/shared-resources/identity/adapters/inbound/flask/endpoints/identity_routes.py
+++ b/shared-resources/identity/adapters/inbound/flask/endpoints/identity_routes.py
@@ -27,7 +27,14 @@ def resolve_identity():
 
         if identity_type == "user":
             if svc.has_directory:
-                token = request.headers.get("X-User-Token")
+                auth_manager = current_app.extensions.get('auth_manager')
+                token = None
+                if auth_manager:
+                    sd = auth_manager._get_server_session()
+                    if sd:
+                        token = sd.get('access_token')
+                if not token:
+                    token = request.headers.get("X-User-Token")  # ponytail: backward compat fallback
                 user = svc.get_directory_user(identity_id, user_token=token)
                 if user:
                     identity = Identity.user(

--- a/shared-resources/identity/utils/auth_manager.py
+++ b/shared-resources/identity/utils/auth_manager.py
@@ -388,11 +388,9 @@ class AuthManager:
             # Add admin permission based on config (checks admin_allowed_users)
             user['is_admin'] = self._check_admin_permission(user)
 
-            session_data = self._get_server_session() or {}
             return jsonify({
                 'user': user,
                 'authenticated': True,
-                'access_token': session_data.get('access_token'),
             })
         
         @self.app.route('/api/auth/user/groups')

--- a/ui/client/src/api/directory.ts
+++ b/ui/client/src/api/directory.ts
@@ -20,12 +20,6 @@ export interface DirectorySearchResult {
   groups: DirectoryGroup[];
 }
 
-function authHeaders(accessToken?: string | null): Record<string, string> {
-  const h: Record<string, string> = {};
-  if (accessToken) h['X-User-Token'] = accessToken;
-  return h;
-}
-
 export async function getDirectoryStatus(): Promise<{ enabled: boolean }> {
   const { data } = await identityApi.get<{ enabled: boolean }>('/directory/directory.status');
   return data;
@@ -34,11 +28,10 @@ export async function getDirectoryStatus(): Promise<{ enabled: boolean }> {
 export async function searchDirectoryUsers(
   query: string,
   limit: number = 10,
-  accessToken?: string | null,
 ): Promise<DirectoryUser[]> {
   const { data } = await identityApi.get<{ users: DirectoryUser[] }>(
     '/directory/directory.search_users',
-    { params: { q: query, limit }, headers: authHeaders(accessToken) },
+    { params: { q: query, limit } },
   );
   return data.users;
 }
@@ -46,22 +39,20 @@ export async function searchDirectoryUsers(
 export async function searchDirectory(
   query: string,
   limit: number = 10,
-  accessToken?: string | null,
 ): Promise<DirectorySearchResult> {
   const { data } = await identityApi.get<DirectorySearchResult>(
     '/directory/directory.search',
-    { params: { q: query, limit }, headers: authHeaders(accessToken) },
+    { params: { q: query, limit } },
   );
   return data;
 }
 
 export async function getDirectoryGroup(
   groupId: string,
-  accessToken?: string | null,
 ): Promise<DirectoryGroup> {
   const { data } = await identityApi.get<DirectoryGroup>(
     '/directory/directory.get_group',
-    { params: { groupId }, headers: authHeaders(accessToken) },
+    { params: { groupId } },
   );
   return data;
 }

--- a/ui/client/src/components/shared/SharedPanel.tsx
+++ b/ui/client/src/components/shared/SharedPanel.tsx
@@ -41,7 +41,7 @@ export default function SharedPanel({ isOpen, onClose }: SharedPanelProps) {
   } = useShared();
 
   const { viewMode, selectedTeam, teams } = useView();
-  const { user, accessToken } = useAuth();
+  const { user } = useAuth();
 
   const [sendForm, setSendForm] = useState({
     recipientUserId: '',
@@ -286,7 +286,6 @@ export default function SharedPanel({ isOpen, onClose }: SharedPanelProps) {
             onSelect={handleRecipientSelect}
             onInputChange={handleRecipientInputChange}
             clearOnSelect={false}
-            accessToken={accessToken}
             placeholder="Search for a user..."
             inputClassName="bg-gray-800 border-gray-600 input-dark-theme-text-white placeholder:!text-gray-400"
           />

--- a/ui/client/src/components/shared/UserDirectorySearch.tsx
+++ b/ui/client/src/components/shared/UserDirectorySearch.tsx
@@ -18,7 +18,6 @@ interface UserDirectorySearchProps {
   excludeUserIds?: string[];
   placeholder?: string;
   clearOnSelect?: boolean;
-  accessToken?: string | null;
   inputClassName?: string;
 }
 
@@ -29,7 +28,6 @@ export default function UserDirectorySearch({
   excludeUserIds = [],
   placeholder,
   clearOnSelect = true,
-  accessToken,
   inputClassName,
 }: UserDirectorySearchProps) {
   const [directoryEnabled, setDirectoryEnabled] = useState(true);
@@ -114,8 +112,8 @@ export default function UserDirectorySearch({
         const id = requestId;
         try {
           const result = onSelectGroup
-            ? await searchDirectory(value.trim(), 10, accessToken)
-            : { users: await searchDirectoryUsers(value.trim(), 10, accessToken), groups: [] };
+            ? await searchDirectory(value.trim(), 10)
+            : { users: await searchDirectoryUsers(value.trim(), 10), groups: [] };
           if (id !== searchIdRef.current) return;
           searchCacheRef.current.set(trimmed, result);
           const filteredUsers = result.users.filter((u) => !excludeUserIdsRef.current.includes(u.user_id));
@@ -127,7 +125,7 @@ export default function UserDirectorySearch({
           // so people can continue selecting users while group lookup is down.
           if (onSelectGroup) {
             try {
-              const users = await searchDirectoryUsers(value.trim(), 10, accessToken);
+              const users = await searchDirectoryUsers(value.trim(), 10);
               if (id !== searchIdRef.current) return;
               const filteredUsers = users.filter((u) => !excludeUserIdsRef.current.includes(u.user_id));
               setUserResults(filteredUsers);
@@ -150,7 +148,7 @@ export default function UserDirectorySearch({
         }
       }, 250);
     },
-    [directoryEnabled, accessToken, onInputChange, onSelectGroup],
+    [directoryEnabled, onInputChange, onSelectGroup],
   );
 
   const handleSelectUser = (user: DirectoryUser) => {

--- a/ui/client/src/components/teams/TeamSettingsModal.tsx
+++ b/ui/client/src/components/teams/TeamSettingsModal.tsx
@@ -33,7 +33,7 @@ interface TeamSettingsModalProps {
 }
 
 export default function TeamSettingsModal({ open, onOpenChange, team }: TeamSettingsModalProps) {
-  const { user, accessToken } = useAuth();
+  const { user } = useAuth();
   const { refreshTeams } = useView();
   const [teamName, setTeamName] = useState("");
   const [members, setMembers] = useState<TeamMember[]>([]);
@@ -128,7 +128,7 @@ export default function TeamSettingsModal({ open, onOpenChange, team }: TeamSett
 
     setLoadingGroupMembers((prev) => new Set(prev).add(groupId));
     try {
-      const group = await getDirectoryGroup(groupId, accessToken);
+      const group = await getDirectoryGroup(groupId);
       setGroupMembersCache((prev) => ({ ...prev, [groupId]: group.members }));
       setMembers((prev) =>
         prev.map((m) =>
@@ -250,7 +250,6 @@ export default function TeamSettingsModal({ open, onOpenChange, team }: TeamSett
                   onSelect={addMemberFromDirectory}
                   onSelectGroup={addGroupAsReference}
                   excludeUserIds={userMemberIds}
-                  accessToken={accessToken}
                   inputClassName="bg-background-dark border-gray-700 text-gray-100 placeholder:text-gray-500"
                 />
               </div>

--- a/ui/client/src/contexts/AuthContext.tsx
+++ b/ui/client/src/contexts/AuthContext.tsx
@@ -13,7 +13,6 @@ export interface User {
 
 export interface AuthContextType {
   user: User | null;
-  accessToken: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   login: () => void;
@@ -29,7 +28,6 @@ interface AuthProviderProps {
 
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
-  const [accessToken, setAccessToken] = useState<string | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -42,17 +40,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       const response = await api.get('/auth/user');
       if (response.data.authenticated && response.data.user) {
         setUser(response.data.user);
-        setAccessToken(response.data.access_token ?? null);
         setIsAuthenticated(true);
       } else {
         setUser(null);
-        setAccessToken(null);
         setIsAuthenticated(false);
       }
     } catch (error) {
       console.error('Auth check failed:', error);
       setUser(null);
-      setAccessToken(null);
       setIsAuthenticated(false);
     } finally {
       setIsLoading(false);
@@ -176,7 +171,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const value: AuthContextType = {
     user,
-    accessToken,
     isAuthenticated,
     isLoading,
     login,


### PR DESCRIPTION
## Summary

- The `/api/auth/user` endpoint was returning the raw Keycloak `access_token` in its JSON body. The UI stored this in React state and sent it back via `X-User-Token` header on directory/identity API calls. Any XSS vulnerability or log capture would leak a bearer token that can impersonate the user against Keycloak.
- Directory and identity routes now pull the access token from the server-side Redis session (`auth_manager._get_server_session()`) instead of expecting it from the client.
- The `X-User-Token` request header is still accepted as a fallback so external callers that already send it continue to work without a breaking change.

## Changes

**Backend (Python/Flask)**
- `auth_manager.py` — removed `access_token` from the `/api/auth/user` JSON response
- `directory_routes.py` — `_user_token()` now reads from server-side session first, falls back to header
- `identity_routes.py` — same pattern for the identity resolve endpoint

**Frontend (TypeScript/React)**
- `AuthContext.tsx` — removed `accessToken` from state and context type
- `directory.ts` — removed `accessToken` parameter and `authHeaders` helper from all API functions
- `UserDirectorySearch.tsx` — removed `accessToken` prop
- `TeamSettingsModal.tsx` — removed `accessToken` from `useAuth()` destructure
- `SharedPanel.tsx` — removed `accessToken` from `useAuth()` destructure

## Backward compatibility

The `X-User-Token` header is still read as a fallback in both `directory_routes.py` and `identity_routes.py`, so any external tooling or API clients that currently send this header will continue to work. The fallback can be removed in a future release once all callers have migrated.

## Test plan

- [ ] Log in via Keycloak and verify `/api/auth/user` response no longer contains `access_token`
- [ ] Verify directory user/group search still works from the UI (token now sourced server-side)
- [ ] Verify identity resolve endpoint still works
- [ ] Verify team settings modal group expansion still fetches members
- [ ] Verify share panel user search still works
- [ ] Confirm no `X-User-Token` header is sent in browser network tab on directory requests