### PR TITLE
security: remove hardcoded prod MongoDB IP and fix CI credential exposure

### DIFF
--- a/ci/pipeline-deploy.groovy
+++ b/ci/pipeline-deploy.groovy
@@ -279,7 +279,7 @@ pipeline {
                             string(credentialsId: "${ClusterCredsId}", variable: 'token'),
                         ]){
                             echo("Creating helm deployment pod")
-                            sh("oc login --token=${token} --server=${ClusterAddress}")
+                            sh('oc login --token=$token --server=' + ClusterAddress)
                             sh("oc project ${NameSpace}")
                             echo("Deploy Helm container")
                             sh("podman run --replace -dt --env-file=${vaultEnvFile} --env-file=${configEnvFile} --workdir /helm/charts -v .:/helm/charts:Z -v ~/.kube/:/helm/.kube:Z --name helmfile ghcr.io/helmfile/helmfile:latest bash")

--- a/scripts/migrate_naive_datetimes_to_utc.py
+++ b/scripts/migrate_naive_datetimes_to_utc.py
@@ -30,7 +30,7 @@ import pymongo
 from pymongo import UpdateOne
 
 # Default MongoDB connection settings
-DEFAULT_MONGO_URI = "mongodb://10.46.254.131:27017/"
+DEFAULT_MONGO_URI = "mongodb://localhost:27017/"
 DEFAULT_DB_NAME = "UnifAI"
 
 # Collection configurations: (collection_name, list of datetime field paths)


### PR DESCRIPTION
## Summary

Two security fixes for credential/address exposure:

### 1. Hardcoded production MongoDB IP in migration script

`scripts/migrate_naive_datetimes_to_utc.py` defaulted to `mongodb://10.46.254.131:27017/` — a real production server IP. Running the script without explicitly passing `--mongo-uri` would connect to and potentially modify production data. Every other migration script in `scripts/` defaults to `localhost`.

**Fix:** Changed `DEFAULT_MONGO_URI` to `mongodb://localhost:27017/`.

### 2. Jenkins pipeline credential exposure via Groovy string interpolation

`ci/pipeline-deploy.groovy` used double-quoted `sh("oc login --token=${token} ...")` inside a `withCredentials` block. Groovy expands `${token}` at string interpolation time (before the shell runs), embedding the literal token value into the command string. This makes the token visible in Jenkins console output, `ps aux` process listings, and shell history — defeating `withCredentials` masking.

**Fix:** Changed to single-quoted shell string `sh('oc login --token=$token --server=' + ClusterAddress)` so `$token` is resolved by the shell from the environment variable that `withCredentials` sets, keeping the credential out of the command string logged by Jenkins.

## Test plan

- [ ] Verify `migrate_naive_datetimes_to_utc.py` defaults to localhost when no `--mongo-uri` is provided
- [ ] Verify Jenkins pipeline still authenticates to OpenShift correctly with the single-quoted token reference
- [ ] Confirm Jenkins console output no longer shows the token value in the `oc login` command